### PR TITLE
Typos, Line Breaks

### DIFF
--- a/docs/datastructures.md
+++ b/docs/datastructures.md
@@ -6,17 +6,17 @@ In diesem Kapitel werden einige Dinge, die bereits in vorherigen Kapiteln beschr
 
 Der Datentyp Liste hat einige weitere Methoden. Im Folgenden alle Methoden von Listenobjekten:
 
-*Hinweis*: in den folgenden Beispielen - und vielen anderen Beispielen in der Python-Dokumentation - kennzeichnen eckige Klammern innerhalb eines Methodenaufrufs ein optionales Argument. So bedeutet z.B. `a.pop([i])`, dass die Methode `pop` von `a` entweder mit einem Argument wie `a.pop(4)` oder ohne `a.pop()` aufgrrufen werden kann.
+*Hinweis*: In den folgenden Beispielen - und vielen anderen Beispielen in der Python-Dokumentation - kennzeichnen eckige Klammern innerhalb eines Methodenaufrufs ein optionales Argument. So bedeutet z.B. `a.pop([i])`, dass die Methode `pop` von `a` entweder mit einem Argument wie `a.pop(4)` oder ohne `a.pop()` aufgerufen werden kann.
 
  * `list.append(x)`: fügt ein Element `x` am Ende der Liste hinzu. Äquivalent zu `a[len(a):] = x`.
  * `list.extend(iterable)`: Erweitert die Liste um alle Elemente aus der Sequenz `iterable`. Äquivalent zu `a[len(a):] = iterable`.
  * `list.insert(i, x)`: Fügt ein Element `x` vor dem Element an Position `i` der Liste hinzu. `list.insert(0, x)` würde also das Elemente `x` an den Anfang der Liste einsetzen. `list.insert(len(list), x)` ist äquivalent zu `list.append(x)`.
- * `list.remove(x)`: Entfernt das erste Element aus der Liste, dessen Wert gleich `x` ist. Wird kein Element gefunden erhält man einen `ValueError`.
+ * `list.remove(x)`: Entfernt das erste Element aus der Liste, dessen Wert gleich `x` ist. Wird kein Element gefunden, erhält man einen `ValueError`.
  * `list.pop([i])`: Entfernt das Element an der Position `i` aus der Liste und liefert es als Rückgabewert zurück. Wenn nur `list.pop()` ohne Index angegeben wird, wird das letzte Element aus der Liste entfernt.
- * `list.clear()`: Entfernt alle Elemente aus der Liste, so dass diese leer ist. Äquivalent zu `del list[:]`.
- * `list.index(x[, start[, end]])`: Gibt den Index des ersten Elements zurück, dessen Wert gleich `x` ist. Wird kein Element gefunden erhält man einen `ValueError`. Gibt man die Optionalen Elemente `start` und `end` an wird nur in dem Abschnitt zwischen den Indizes `start` und `end` gesucht. Wird ein Element in dem Abschnitt gefunden wird dessen Index relativ zur gesamten Liste angegeben, nicht relativ zum Index des Starts.
- * `list.count(x)`: Liefert an Anzahl der Vorkommen von `x` in der Liste zurück.
- * `list.sort(*, key=None, reverse=False)`: Sortiert die Liste in-situ, d.h. es wird keine neue Liste zurück geliefert, sondern die Liste an sich wieder sortiert. Die möglichen Argumente und Optionen sind identisch mit der der Built-In Funktion [sorted](https://docs.python.org/3/library/functions.html#sorted).
+ * `list.clear()`: Entfernt alle Elemente aus der Liste, sodass diese leer ist. Äquivalent zu `del list[:]`.
+ * `list.index(x[, start[, end]])`: Gibt den Index des ersten Elements zurück, dessen Wert gleich `x` ist. Wird kein Element gefunden erhält man einen `ValueError`. Gibt man die optionalen Elemente `start` und `end` an wird nur in dem Abschnitt zwischen den Indizes `start` und `end` gesucht. Wird ein Element in dem Abschnitt gefunden wird dessen Index relativ zur gesamten Liste angegeben, nicht relativ zum Index des Starts.
+ * `list.count(x)`: Liefert die Anzahl der Vorkommen von `x` in der Liste zurück.
+ * `list.sort(*, key=None, reverse=False)`: Sortiert die Liste in-situ, d.h. es wird keine neue Liste zurückgeliefert, sondern die Liste an sich wieder sortiert. Die möglichen Argumente und Optionen sind identisch mit der Built-In Funktion [sorted](https://docs.python.org/3/library/functions.html#sorted).
  * `list.reverse()`: Kehrt die Reihenfolge der Elemente in der Liste um. Die Liste wird direkt umgekehrt, es wird keine neue Liste zurückgegeben.
  * `list.copy()`: Liefert eine flache Kopie der Liste zurück. Äquivalent zu `list[:]`.
 
@@ -45,9 +45,9 @@ Ein Beispiel, das die meisten der Listenmethoden verwendet:
 'pear'
 ```
 
-Wie oben bereits erwähnt sind Methoden wie `insert`, `remove` oder `sort` solche, die die Liste verändern und keinen Rückgabewert ausgeben - sie liefern den Standardwert `None`. Dies ist grundsätzliche Designprinzip für alle veränderbaren Datenstrukturen in Python.
+Wie oben bereits erwähnt sind Methoden wie `insert`, `remove` oder `sort` solche, die die Liste verändern und keinen Rückgabewert ausgeben - sie liefern den Standardwert `None`. Dies ist grundsätzliches Designprinzip für alle veränderbaren Datenstrukturen in Python.
 
-Eine andere Sache, die vielleicht bemerken wurde, ist, dass nicht alle Daten sortiert oder verglichen werden können.  Zum Beispiel kann `[None, 'hello', 10]` nicht sortiert werden, weil Ganzzahlen nicht mit Zeichenketten und `None` nicht mit anderen Typen verglichen werden können. Außerdem gibt es einige Typen, die keine definierte Ordnungsbeziehung haben. Zum Beispiel komplexe Zahlen. So ist `3+4j < 5+7j` kein gültiger Vergleich.
+Eine andere erwähenenswerte Sache ist, dass nicht alle Daten sortiert oder verglichen werden können. Zum Beispiel kann `[None, 'hello', 10]` nicht sortiert werden, weil Ganzzahlen nicht mit Zeichenketten und `None` nicht mit anderen Typen verglichen werden können. Außerdem gibt es einige Typen, die keine definierte Ordnungsbeziehung haben. Zum Beispiel komplexe Zahlen. So ist `3+4j < 5+7j` kein gültiger Vergleich.
 
 ### Listen als Stacks
 
@@ -92,7 +92,7 @@ deque(['Michael', 'Terry', 'Graham'])
 
 ### List Comprehensions
 
-List Comprehensions bieten eine kompakte Möglichkeit, Listen zu erstellen. Übliche Anwendungen sind die Erstellung neuer Listen, bei denen jedes Element das Ergebnis einer oder einiger Operation(en) ist, die auf jedes Element einer anderen Sequenz oder Iterables angewandt werden. Eine weiter Anwendung ist die Erstellung einer Teilfolge von Elementen, die eine bestimmte Bedingung erfüllen.
+List Comprehensions bieten eine kompakte Möglichkeit Listen zu erstellen. Übliche Anwendungen sind die Erstellung neuer Listen bei denen jedes Element das Ergebnis einer oder einiger Operation(en) ist, die auf jedes Element einer anderen Sequenz oder Iterables angewandt werden. Eine weitere Anwendung ist die Erstellung einer Teilfolge von Elementen, die eine bestimmte Bedingung erfüllen.
 
 Wenn z.B. eine Liste mit den Quadratzahlen von 1 bis 9 angelegt werden soll, geht das konventionell so:
 
@@ -119,7 +119,7 @@ Mittels List Comprehension funktioniert das wie folgt:
 
 List Comprehensions sind im Vergleich zu den beiden zuvor genannten Wegen kompakter und besser lesbar.
 
-Eine List Comprehension besteht aus Klammern, die einen Ausdruck enthalten, gefolgt von einer `for` Klausel, dann null oder mehr `for` oder `if` Klauseln. Das Ergebnis ist eine neue Liste, die sich aus der Auswertung des Ausdrucks im Kontext der nachfolgenden `for` und `if` Klauseln ergibt. Zum Beispiel kombiniert dieser List Comprehension die Elemente zweier Listen, wenn sie nicht gleich sind:
+Eine List Comprehension besteht aus Klammern die einen Ausdruck enthalten, gefolgt von einer `for` Klausel, dann null oder mehr `for` oder `if` Klauseln. Das Ergebnis ist eine neue Liste, die sich aus der Auswertung des Ausdrucks im Kontext der nachfolgenden `for` und `if` Klauseln ergibt. Zum Beispiel kombiniert dieser List Comprehension die Elemente zweier Listen, wenn sie nicht gleich sind:
 
 ```pycon
 >>> [(x, y) for x in [1,2,3] for y in [3,1,4] if x != y]
@@ -180,7 +180,7 @@ List Comprehensions können komplexe Ausdrücke und verschachtelte Funktionen en
 ['3.1', '3.14', '3.142', '3.1416', '3.14159']
 ```
 
-List Comprehensions gelten im allgemeinen als "pythonisch" und werden entsprechend häufig verwendet bzw. es gilt allgemein als empfehlenswert, List Comprehensions an passenden Stellen im Code zu verwenden.
+List Comprehensions gelten im Allgemeinen als "pythonisch" und werden entsprechend häufig verwendet bzw. es gilt allgemein als empfehlenswert, List Comprehensions an passenden Stellen im Code zu verwenden.
 
 ### verschachtelte List Comprehensions
 
@@ -269,7 +269,7 @@ würde `del a` die Referenz von `a` auf den String "Python" aus dem aktuellen Na
 
 ## Tupel und Sequenzen
 
-Es wurde schon gezeigt, dass Listen und Zeichenketten viele gemeinsame Eigenschaften haben, z. B. Index- und Slicing-Operationen. Dies sind zwei Beispiele für *Sequenz*-Datentypen (siehe [Sequenz Typen — list, tuple, range](https://docs.python.org/3/library/stdtypes.html#typesseq)). Da Python eine sich entwickelnde Sprache ist, könnten weitere Sequenz-Datentypen hinzugefügt werden. Es gibt auch einen anderen Standard-Sequenz-Datentyp: das *Tupel* (auf englisch: tuple).
+Es wurde schon gezeigt, dass Listen und Zeichenketten viele gemeinsame Eigenschaften haben, z. B. Index- und Slicing-Operationen. Dies sind zwei Beispiele für *Sequenz*-Datentypen (siehe [Sequenz Typen — list, tuple, range](https://docs.python.org/3/library/stdtypes.html#typesseq)). Da Python eine sich entwickelnde Sprache ist, könnten weitere Sequenz-Datentypen hinzugefügt werden. Es gibt auch einen anderen Standard-Sequenz-Datentyp: das *Tupel* (auf Englisch: tuple).
 
 Ein Tupel besteht aus einer Reihe von Werten, die durch Kommas getrennt sind, zum Beispiel:
 
@@ -295,11 +295,11 @@ TypeError: 'tuple' object does not support item assignment
 ([1, 2, 3], [3, 2, 1])
 ```
 
-Wie zu sehen ist, werden Tupel bei der Ausgabe immer in Klammern eingeschlossen, damit verschachtelte Tupel korrekt interpretiert werden. Sie können mit oder ohne umgebende Klammern eingegeben werden, obwohl Klammern oft ohnehin notwendig sind, z.B wenn das Tupel Teil eines größeren Ausdrucks ist. Es ist nicht möglich, den einzelnen Elementen eines Tupels Zuweisungen zuzuweisen. Es ist jedoch möglich, Tupel zu erstellen, die veränderbare Objekte enthalten, z. B. Listen.
+Wie zu sehen ist, werden Tupel bei der Ausgabe immer in Klammern eingeschlossen, damit verschachtelte Tupel korrekt interpretiert werden. Sie können mit oder ohne umgebende Klammern eingegeben werden, obwohl Klammern oft ohnehin notwendig sind, z.B. wenn das Tupel Teil eines größeren Ausdrucks ist. Es ist nicht möglich, den einzelnen Elementen eines Tupels Zuweisungen zuzuweisen. Es ist jedoch möglich, Tupel zu erstellen, die veränderbare Objekte enthalten, z. B. Listen.
 
 Obwohl Tupel auf den ersten Blick ähnlich wie Listen aussehen, werden sie oft in unterschiedlichen Situationen und für unterschiedliche Zwecke verwendet. Tupel sind "immutable" (=unveränderlich) und enthalten in der Regel eine heterogene Folge von Elementen, auf die durch Entpacken (siehe später in diesem Abschnitt) oder Indizierung (oder sogar durch Attribute im Fall von [namedtuples](https://docs.python.org/3/library/collections.html#collections.namedtuple)) zugegriffen wird. Listen sind "mutable" (=veränderlich), und ihre Elemente sind normalerweise homogen und werden durch Iteration über die Liste angesprochen.
 
-Ein spezielles Problem ist die Konstruktion von Tupeln, die 0 oder 1 Elemente enthalten: Die Syntax hat einige zusätzliche Eigenheiten, um diese zu berücksichtigen. Leere Tupel werden durch ein leeres Klammerpaar konstruiert. Ein Tupel mit einem Element wird konstruiert, indem einem Wert ein Komma folgt - es genügt nicht, einen einzelnen Wert in Klammern zu setzen! Hässlich, aber effektiv.  Zum Beispiel:
+Ein spezielles Problem ist die Konstruktion von Tupeln, die 0 oder 1 Elemente enthalten: Die Syntax hat einige zusätzliche Eigenheiten, um diese zu berücksichtigen. Leere Tupel werden durch ein leeres Klammerpaar konstruiert. Ein Tupel mit einem Element wird konstruiert, indem einem Wert ein Komma folgt - es genügt nicht, einen einzelnen Wert in Klammern zu setzen! Hässlich, aber effektiv. Zum Beispiel:
 
 ```pycon
 >>> empty = ()
@@ -326,7 +326,7 @@ Python enthält auch einen Datentyp für *Sets* (auf Deutsch: Menge). Ein Set is
 
 Geschweifte Klammern oder die Funktion [set](https://docs.python.org/3/library/stdtypes.html#set) können verwendet werden, um Mengen zu erzeugen.
 
-*Hinweis*: Um eine leere Menge zu erzeugen, muss `set()`` verwendet werden, nicht `{}`! Letzteres erzeugt ein leeres Wörterbuch, eine Datenstruktur, die im nächsten Abschnitt behandelt wird.
+*Hinweis*: Um eine leere Menge zu erzeugen, muss `set()` verwendet werden, nicht `{}`! Letzteres erzeugt ein leeres Wörterbuch, eine Datenstruktur, die im nächsten Abschnitt behandelt wird.
 
 Eine kurze Demonstration zu Sets:
 
@@ -363,17 +363,17 @@ Analog zu List Comprehensions gibt es auch Set Comprehensions:
 
 ## Dictionaries - Wörterbücher
 
-Ein weiterer nützlicher Datentyp, der in Python eingebaut und sehr oft verwendet wird, ist das *Dictionary* (auf Deutsch: Wörterbuch). Wörterbücher sind vom Typ [mapping](https://docs.python.org/3/library/stdtypes.html#typesmapping)- Wörterbücher sind zur Zeit die einzige Datenstruktur vom Typ mapping. Für Wörterbücher ist als Bezeichnung auch der Begriff "dict" (Kurzform für Dictionary) gebräuchlich.
+Ein weiterer nützlicher Datentyp, der in Python eingebaut und sehr oft verwendet wird, ist das *Dictionary* (auf Deutsch: Wörterbuch). Wörterbücher sind vom Typ [mapping](https://docs.python.org/3/library/stdtypes.html#typesmapping). Wörterbücher sind gegenwärtig die einzige Datenstruktur vom Typ mapping. Für Wörterbücher ist als Bezeichnung auch der Begriff "dict" (Kurzform für Dictionary) gebräuchlich.
 
 Wörterbücher sind in anderen Sprachen manchmal als "assoziative Speicher" oder "assoziative Arrays" bekannt. Im Gegensatz zu Sequenzen, die durch einen Zahlenbereich indiziert werden, werden Wörterbücher durch *Schlüssel* indiziert, die jeder unveränderliche Typ sein können. Strings und Zahlen können ein Schlüssel sein. Tupel können als Schlüssel verwendet werden, wenn sie nur Strings, Zahlen oder Tupel enthalten. Wenn ein Tupel direkt oder indirekt ein veränderbares Objekt enthält, kann es nicht als Schlüssel verwendet werden. Listen können nicht als Schlüssel verwendet werden, da Listen mit Indexzuweisungen, Slice-Zuweisungen oder Methoden `list.append` und `list.extend` an Ort und Stelle verändert werden können.
 
 Am besten stellt man sich ein Wörterbuch als eine Menge von *Schlüssel-Wert*-Paaren vor, wobei die Schlüssel innerhalb eines Wörterbuchs eindeutig sein müssen. Ein Paar geschweifte Klammern erzeugt ein leeres Wörterbuch: `{}`. Eine kommagetrennte Liste von Schlüssel-Wert Paaren innerhalb der geschweiften Klammern fügt dem Wörterbuch erste Schlüssel-Wert Paare hinzu. Dies ist auch die Art und Weise, wie Wörterbücher bei der Ausgabe geschrieben werden.
 
-Die wichtigsten Operationen mit einem Wörterbuch sind das Speichern eines Wertes mit einem Schlüssel und das Extrahieren des Wertes mit Hilfe des Schlüssels. Es ist auch möglich, ein Schlüssel-Wert-Paar mit `del` zu löschen. Wenn man einen Schlüssel speichert, der bereits in Gebrauch ist, wird der alte Wert, der mit diesem Schlüssel verbunden war, überschrieben. Wenn man auf einen Schlüssel zugreifen will, der nicht existiert, erhält man einen `KeyError`.
+Die wichtigsten Operationen mit einem Wörterbuch sind das Speichern eines Wertes mit einem Schlüssel und das Extrahieren des Wertes mithilfe des Schlüssels. Es ist auch möglich, ein Schlüssel-Wert-Paar mit `del` zu löschen. Wenn man einen Schlüssel speichert, der bereits in Gebrauch ist, wird der alte Wert, der mit diesem Schlüssel verbunden war, überschrieben. Greift man auf einen Schlüssel zu, der nicht existiert, erhält man einen `KeyError`.
 
 Wenn man ``list(d)`` auf ein Wörterbuch anwendet, erhält man eine Liste aller Schlüssel, die in dem Wörterbuch verwendet werden - und zwar in der Reihenfolge, in der die Schlüssel hinzugefügt wurden. Wenn man die SChlüssel aplhapbetisch sortiert haben will, verwendet man stattdessen `sorted(d)`. Um zu prüfen, ob ein einzelner Schlüssel im Wörterbuch enthalten ist, verwendet man das Schlüsselwort `in`.
 
-Im Folgenden ein kleine Beispiel für die Nutzung als Wörterbuch:
+Im Folgenden ein kleines Beispiel für die Nutzung als Wörterbuch:
 
 ```pycon
 >>> tel = {'jack': 4098, 'sape': 4139}   # Anlegen von tel mit zwei Schlüssel-Werte Paaren
@@ -543,11 +543,11 @@ Manchmal ist es verlockend, eine Liste zu ändern, während man sie in einer Sch
 
 Die in `while` und `if` Anweisungen verwendeten Bedingungen können beliebige Operatoren enthalten, nicht nur einfache Vergleiche.
 
-Die Vergleichsoperatoren `in` und `not in` sind Zugehörigkeitstests, die feststellen, ob ein Wert in einem Container wie z.B. einer Sequenz oder einem Wörterbuch ist (oder nicht). Die Operatoren `is` und `is not` vergleichen, ob zwei Objekte wirklich dasselbe Objekt sind.  Alle Vergleichsoperatoren haben die gleiche Priorität, die niedriger ist als die aller numerischen Operatoren.
+Die Vergleichsoperatoren `in` und `not in` sind Zugehörigkeitstests, die feststellen, ob ein Wert in einem Container wie z.B. einer Sequenz oder einem Wörterbuch ist (oder nicht). Die Operatoren `is` und `is not` vergleichen, ob zwei Objekte wirklich dasselbe Objekt ist. Alle Vergleichsoperatoren haben die gleiche Priorität, die niedriger ist als die aller numerischen Operatoren.
 
-Vergleiche können verkettet werden. Zum Beispiel testet `a < b == c`, ob `a`` kleiner als `b`` ist und außerdem `b` gleich `c` ist.
+Vergleiche können verkettet werden. Zum Beispiel testet `a < b == c`, ob `a` kleiner als `b` ist und außerdem `b` gleich `c` ist.
 
-Vergleiche können mit den booleschen Operatoren `and` und `or` kombiniert werden, und das Ergebnis eines Vergleichs (oder jedes anderen booleschen Ausdrucks) kann mit `not` negiert werden. Diese haben eine niedrigere Priorität als Vergleichsoperatoren. Zwischen ihnen hat `not` die höchste Priorität und `or` die niedrigste, so dass `A and not B or C` äquivalent zu `(A and (not B)) or C` ist. Wie immer können Klammern verwendet werden, um die gewünschte Zusammensetzung auszudrücken.
+Vergleiche können mit den booleschen Operatoren `and` und `or` kombiniert werden, und das Ergebnis eines Vergleichs (oder jedes anderen booleschen Ausdrucks) kann mit `not` negiert werden. Diese haben eine niedrigere Priorität als Vergleichsoperatoren. Zwischen ihnen hat `not` die höchste Priorität und `or` die niedrigste, sodass `A and not B or C` äquivalent zu `(A and (not B)) or C` ist. Wie immer können Klammern verwendet werden, um die gewünschte Zusammensetzung auszudrücken.
 
 Beispiel dazu: Im Folgenden Bespiel spielt der Wert von `C` für den Vergleich beim `if` keine Rolle, weil bereits `A and not B` wahr ist und dadurch das `... or C` nicht mehr relevant ist:
 
@@ -566,7 +566,7 @@ ist wahr
 ist wahr
 ```
 
-Die booleschen Operatoren `and` und `or` sind sogenannte *Kurzschluss*-Operatoren: ihre Argumente werden von links nach rechts ausgewertet, und die Auswertung endet, sobald das Ergebnis feststeht. Wenn zum Beispiel `A` und `C` wahr sind, aber `B` falsch ist, wertet `A and B and C` den Ausdruck `C` nicht aus. Wenn er als allgemeiner Wert und nicht als Boolescher Wert verwendet wird, ist der Rückgabewert eines Kurzschlussoperators das zuletzt ausgewertete Argument.
+Die booleschen Operatoren `and` und `or` sind sogenannte *Kurzschluss*-Operatoren: Ihre Argumente werden von links nach rechts ausgewertet, und die Auswertung endet, sobald das Ergebnis feststeht. Wenn zum Beispiel `A` und `C` wahr sind, aber `B` falsch ist, wertet `A and B and C` den Ausdruck `C` nicht aus. Wenn er als allgemeiner Wert und nicht als Boolescher Wert verwendet wird, ist der Rückgabewert eines Kurzschlussoperators das zuletzt ausgewertete Argument.
 
 Es ist möglich, das Ergebnis eines Vergleichs oder eines anderen booleschen Ausdrucks einer Variablen zuzuweisen. Zum Beispiel:
 
@@ -577,7 +577,7 @@ Es ist möglich, das Ergebnis eines Vergleichs oder eines anderen booleschen Aus
 'Trondheim'
 ```
 
-Zu beachten ist, dass in Python, anders als in C, Zuweisungen innerhalb von Ausdrücken explizit mit dem [walrus](https://docs.python.org/3/faq/design.html#why-can-t-i-use-an-assignment-in-an-expression) Operator `:=` erfolgen müssen. Dies vermeidet eine häufige Klasse von Problemen, die in C-Programmen auftreten: die Eingabe von ``=`` in einem Ausdruck, obwohl ``==`` beabsichtigt war.
+Zu beachten ist, dass in Python, anders als in C, Zuweisungen innerhalb von Ausdrücken explizit mit dem [walrus](https://docs.python.org/3/faq/design.html#why-can-t-i-use-an-assignment-in-an-expression) Operator `:=` erfolgen müssen. Dies vermeidet eine häufige Form von Problemen, die in C-Programmen auftreten: die Eingabe von ``=`` in einem Ausdruck, obwohl ``==`` beabsichtigt war.
 
 ## Vergleiche von Sequenzen und anderen Datentypen
 
@@ -593,7 +593,7 @@ Sequenzobjekte können normalerweise mit anderen Objekten desselben Sequenztyps 
    (1, 2, ('aa', 'ab'))   < (1, 2, ('abc', 'a'), 4)
 ```
 
-Zu beachten ist, dass der Vergleich von Objekten unterschiedlichen Typs mit `<` oder `>` zulässig ist, sofern die Objekte über geeignete Vergleichsmethoden verfügen. Zum Beispiel werden gemischte numerische Typen entsprechend ihrem numerischen Wert verglichen, so dass 0 gleich 0.0 ist, usw. Andernfalls wird der Interpreter eine `TypeError` Ausnahme auslösen, anstatt eine beliebige Reihenfolge zu liefern.
+Zu beachten ist, dass der Vergleich von Objekten unterschiedlichen Typs mit `<` oder `>` zulässig ist, sofern die Objekte über geeignete Vergleichsmethoden verfügen. Zum Beispiel werden gemischte numerische Typen entsprechend ihrem numerischen Wert verglichen, sodass 0 gleich 0.0 ist, usw. Andernfalls wird der Interpreter eine `TypeError` Ausnahme auslösen, anstatt eine beliebige Reihenfolge zu liefern.
 
 ***
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,25 +1,12 @@
 # Module
 
-Wird der Python-Interpreter verlassen und erneut aufgerufen, gehen die vorgenommenen Definitionen (Funktionen, Variablen
-etc.) verloren. Schreibt man ein etwas längeres Programm, so ist es besser einen Texteditor zu verwenden, um die Eingabe
-für den Interpreter vorzubereiten und diesen stattdessen mit der Programmdatei als Eingabe zu starten. Dies wird als
-Erstellen eines Skripts bzw. Programms bezeichnet (Anmerkung zur Vermeidung von Missverständnissen: Python-Skript und
-Python-Programm sind synonym, also dasselbe: eine Datei, die Python Code enthält). Wenn das Programm länger wird, möchte
-man es vielleicht in mehrere Dateien aufteilen, um die Wartung und Pflege zu erleichtern. Vielleicht möchte man auch
-eine praktische Funktion, die man geschrieben hat, in mehreren Programmen verwenden, ohne den Code in jedes Programm
-hinein kopieren zu müssen.
+Wird der Python-Interpreter verlassen und erneut aufgerufen, gehen die vorgenommenen Definitionen (Funktionen, Variablen etc.) verloren. Schreibt man ein etwas längeres Programm, so ist es besser einen Texteditor zu verwenden, um die Eingabe für den Interpreter vorzubereiten und diesen stattdessen mit der Programmdatei als Eingabe zu starten. Dies wird als Erstellen eines Skripts bzw. Programms bezeichnet (Anmerkung zur Vermeidung von Missverständnissen: Python-Skript und Python-Programm sind synonym, also dasselbe: eine Datei, die Python Code enthält). Wenn das Programm länger wird, möchte man es vielleicht in mehrere Dateien aufteilen, um die Wartung und Pflege zu erleichtern. Vielleicht möchte man auch eine praktische Funktion, die man geschrieben hat, in mehreren Programmen verwenden, ohne den Code in jedes Programm hinein kopieren zu müssen.
 
-Um dies zu unterstützen, bietet Python eine Möglichkeit, Definitionen in einer Datei abzulegen und sie in einem Skript
-oder in einer interaktiven Instanz des Interpreters zu verwenden. Eine solche Datei wird als *Modul* bezeichnet.
-Definitionen aus einem Modul können in anderen Modulen oder in das *Hauptmodul* (die Sammlung von Variablen, auf die man
-in einem Skript, das auf der obersten Ebene und im Rechnermodus ausgeführt wird, Zugriff hat) *importiert* werden.
+Um dies zu unterstützen, bietet Python eine Möglichkeit, Definitionen in einer Datei abzulegen und sie in einem Skript oder in einer interaktiven Instanz des Interpreters zu verwenden. Eine solche Datei wird als *Modul* bezeichnet. Definitionen aus einem Modul können in anderen Modulen oder in das *Hauptmodul* (die Sammlung von Variablen, auf die man in einem Skript, das auf der obersten Ebene und im Rechnermodus ausgeführt wird, Zugriff hat) *importiert* werden.
 
-Ein Modul ist eine Datei, die Python-Definitionen und Anweisungen enthält. Der Dateiname ist der Modulname mit der
-angehängten Endung `.py`. Innerhalb eines Moduls ist der Name des Moduls (als String) als Wert der globalen
-Variable `__name__` verfügbar, welche automatisch von Python beim Import des Moduls angelegt wird.
+Ein Modul ist eine Datei, die Python-Definitionen und Anweisungen enthält. Der Dateiname ist der Modulname mit der angehängten Endung `.py`. Innerhalb eines Moduls ist der Name des Moduls (als String) als Wert der globalen Variable `__name__` verfügbar, welche automatisch von Python beim Import des Moduls angelegt wird.
 
-Im Folgenden wird eine Datei namens `fibo.py` angelegt, welche dann als Modul importiert wird. Die Datei kann man mit
-seinem bevorzugten Texteditor mit folgendem Inhalt füllen:
+Im Folgenden wird eine Datei namens `fibo.py` angelegt, welche dann als Modul importiert wird. Die Datei kann man mit seinem bevorzugten Texteditor mit folgendem Inhalt füllen:
 
 ```python
 # Fibonacci numbers module
@@ -45,22 +32,16 @@ def fib2(n):
     return result
 ```
 
-Jetzt öffnet man den Python Interpreter in demselben Verzeichnis, in dem die Datei liegt, und führt den folgenden Befehl
-im Interpreter aus:
+Jetzt öffnet man den Python Interpreter in demselben Verzeichnis, in dem die Datei liegt, und führt den folgenden Befehl im Interpreter aus:
 
 ```python
->> > import fibo
->> >
+>>> import fibo
+>>>
 ```
 
-Wenn der Import erfolgreich war, ist man einfach erneut am Prompt und könnte jetzt auf die importieren Funktionen
-zugreifen.
+Wenn der Import erfolgreich war, ist man einfach erneut am Prompt und könnte jetzt auf die importieren Funktionen zugreifen.
 
-Was beim Import passiert: Es wird der Modulname `fibo` im aktuelle Namensraum des Python Interpreter eingefügt. 
-Die beiden Funktionsnamen aus dem `fibo` Modul werden nicht eingefügt, jedenfalls nicht direkt. 
-Mehr zum Thema Namensräume (auf Englisch: namespace) sind in der Python Dokumentation im
-Abschnitt [namespace](https://docs.python.org/3/glossary.html#term-namespace) zu finden. Mehr Informationen zu
-Namensräumen und Gültigkeiten in Namensräumen sind im Kapitel [Klassen](classes.md) in diesem Tutorial zu finden.
+Was beim Import passiert: Es wird der Modulname `fibo` im aktuelle Namensraum des Python Interpreter eingefügt. Die beiden Funktionsnamen aus dem `fibo` Modul werden nicht eingefügt, jedenfalls nicht direkt. Mehr zum Thema Namensräume (auf Englisch: namespace) sind in der Python Dokumentation im Abschnitt [namespace](https://docs.python.org/3/glossary.html#term-namespace) zu finden. Mehr Informationen zu Namensräumen und Gültigkeiten in Namensräumen sind im Kapitel [Klassen](classes.md) in diesem Tutorial zu finden.
 
 Über den Modulnamen kann man auf die Funktionen zugreifen:
 
@@ -73,8 +54,7 @@ Namensräumen und Gültigkeiten in Namensräumen sind im Kapitel [Klassen](class
 'fibo'
 ```
 
-Wenn man eine Funktion häufig verwenden möchten, kann man ihr einen lokalen Namen zuweisen - was aber eher selten
-notwendig ist:
+Wenn man eine Funktion häufig verwenden möchten, kann man ihr einen lokalen Namen zuweisen - was aber eher selten notwendig ist:
 
 ```pycon
 >>> fib = fibo.fib
@@ -82,9 +62,7 @@ notwendig ist:
 0 1 1 2 3 5 8 13 21 34 55 89 144 233 377
 ```
 
-Ohne zu weit in die Tiefe zu gehen sei hier noch erwähnt, dass man nicht nur Funktionen wie im obigen Beispiel
-importieren kann, sondern alle Objekte, die auf oberster Ebene in der Datei stehen. Hätte man z.B. eine Datei `demo.py`
-mit folgendem Inhalt
+Ohne zu weit in die Tiefe zu gehen sei hier noch erwähnt, dass man nicht nur Funktionen wie im obigen Beispiel importieren kann, sondern alle Objekte, die auf oberster Ebene in der Datei stehen. Hätte man z.B. eine Datei `demo.py` mit folgendem Inhalt
 
 ```python
 THE_ANSWER = 42
@@ -98,8 +76,7 @@ class EmptyClass:
     pass
 ```
 
-kann man nach einem Import der Datei auf die Variable `THE_ANSWER`, die Funktion `say_hello_world` und die
-Klasse `EmptyClass` zugreifen:
+kann man nach einem Import der Datei auf die Variable `THE_ANSWER`, die Funktion `say_hello_world` und die Klasse `EmptyClass` zugreifen:
 
 ```pycon
 >>> import demo
@@ -114,23 +91,13 @@ Hello World
 
 ## mehr zu Modulen
 
-Ein Modul kann sowohl ausführbare Anweisungen als auch Funktionsdefinitionen enthalten. Diese Anweisungen dienen der
-Initialisierung des Moduls. Sie werden nur beim *ersten* Auftreten des Modulnamens in einer Import-Anweisung ausgeführt.
-Sie werden immer ausgeführt, auch wenn die Datei als Skript ausgeführt wird (dazu später in diesem Kapitel mehr).
+Ein Modul kann sowohl ausführbare Anweisungen als auch Funktionsdefinitionen enthalten. Diese Anweisungen dienen der Initialisierung des Moduls. Sie werden nur beim *ersten* Auftreten des Modulnamens in einer Import-Anweisung ausgeführt. Sie werden immer ausgeführt, auch wenn die Datei als Skript ausgeführt wird (dazu später in diesem Kapitel mehr).
 
-Jedes Modul hat seinen eigenen privaten Namensraum, der von allen im Modul definierten Funktionen als Namensraum
-verwendet wird. Auf diese Weise kann der Autor eines Moduls globale Variablen im Modul verwenden, ohne sich Gedanken
-über versehentliche Konflikte mit den globalen Variablen eines Benutzers zu machen. Andererseits kann man, wenn man
-weiß, was man tut, die globalen Variablen eines Moduls mit der gleichen Notation ansprechen, mit der man auf die
-Funktionen des Moduls verweist: `Modulname.Funktionsname`.
+Jedes Modul hat seinen eigenen privaten Namensraum, der von allen im Modul definierten Funktionen als Namensraum verwendet wird. Auf diese Weise kann der Autor eines Moduls globale Variablen im Modul verwenden, ohne sich Gedanken über versehentliche Konflikte mit den globalen Variablen eines Benutzers zu machen. Andererseits kann man, wenn man weiß, was man tut, die globalen Variablen eines Moduls mit der gleichen Notation ansprechen, mit der man auf die Funktionen des Moduls verweist: `Modulname.Funktionsname`.
 
-Module können andere Module importieren. Es ist üblich und gilt als "best practice" (ist aber nicht zwingend
-erforderlich), alle `import` Anweisungen an den Anfang eines Moduls (oder Skripts) zu schreiben. Die importierten
-Modulnamen werden, wenn sie auf der obersten Ebene eines Moduls (außerhalb von Funktionen oder Klassen) stehen, dem
-globalen Namensraum des Moduls hinzugefügt.
+Module können andere Module importieren. Es ist üblich und gilt als "best practice" (ist aber nicht zwingend erforderlich), alle `import` Anweisungen an den Anfang eines Moduls (oder Skripts) zu schreiben. Die importierten Modulnamen werden, wenn sie auf der obersten Ebene eines Moduls (außerhalb von Funktionen oder Klassen) stehen, dem globalen Namensraum des Moduls hinzugefügt.
 
-Es gibt eine Variante der `import` Anweisung, die Namen aus einem Modul direkt in den Namensraum des importierenden
-Moduls importiert. Im Folgenden Beispiel werden die Funktionen `fib` und `fib2` aus dem Moduel `fibo` importiert:
+Es gibt eine Variante der `import` Anweisung, die Namen aus einem Modul direkt in den Namensraum des importierenden Moduls importiert. Im Folgenden Beispiel werden die Funktionen `fib` und `fib2` aus dem Moduel `fibo` importiert:
 
 ```pycon
 >>> from fibo import fib, fib2
@@ -138,9 +105,7 @@ Moduls importiert. Im Folgenden Beispiel werden die Funktionen `fib` und `fib2` 
 0 1 1 2 3 5 8 13 21 34 55 89 144 233 377
 ```
 
-Dadurch wird der Modulname, von dem die Importe übernommen werden, nicht in den lokalen Namensraum eingefügt. Im
-Beispiel ist also `fibo` nicht definiert. Ein vorangestelltes `fibo` um auf die Funktionen `fib` und `fib2` zuzugreifen
-ist also nicht notwendig.
+Dadurch wird der Modulname, von dem die Importe übernommen werden, nicht in den lokalen Namensraum eingefügt. Im Beispiel ist also `fibo` nicht definiert. Ein vorangestelltes `fibo` um auf die Funktionen `fib` und `fib2` zuzugreifen ist also nicht notwendig.
 
 Es gibt auch eine Variante, um alle Namen zu importieren, die ein Modul definiert:
 
@@ -150,15 +115,9 @@ Es gibt auch eine Variante, um alle Namen zu importieren, die ein Modul definier
 >>> 0 1 1 2 3 5 8 13 21 34 55 89 144 233 377
 ```
 
-Dies importiert alle Namen außer denen, die mit einem Unterstrich (`_`) beginnen. In den meisten Fällen benutzen
-Python-Programmierer diese Möglichkeit nicht, da sie eine unbekannte Menge von Namen in Namensraum einbinden. Dadurch
-besteht das Risiko, dass bereits bestehend Objekte mit gleichem Namen überschrieben werden. Außerdem ist dann oft
-unklar, wo ein Name herkommt, was zu schlecht lesbarem Code führt. Von daher gelten diese *Sternchen Importe* als
-schlechter Stil und werden in vielen Fällen vermieden.
+Dies importiert alle Namen außer denen, die mit einem Unterstrich (`_`) beginnen. In den meisten Fällen benutzen Python-Programmierer diese Möglichkeit nicht, da sie eine unbekannte Menge von Namen in Namensraum einbinden. Dadurch besteht das Risiko, dass bereits bestehend Objekte mit gleichem Namen überschrieben werden. Außerdem ist dann oft unklar, wo ein Name herkommt, was zu schlecht lesbarem Code führt. Von daher gelten diese *Sternchen Importe* als schlechter Stil und werden in vielen Fällen vermieden.
 
-Folgt auf dem Modulnamen das Schlüsselwort `as`, wird der Name, der auf `as` folgt, direkt an das importierte Modul
-gebunden. Oder anders ausgedrückt: im Namenraum, in den das Modul importiert wird, wird das Modul umbenannt (=an einen
-anderen Namen gebunden):
+Folgt auf dem Modulnamen das Schlüsselwort `as`, wird der Name, der auf `as` folgt, direkt an das importierte Modul gebunden. Oder anders ausgedrückt: im Namenraum, in den das Modul importiert wird, wird das Modul umbenannt (=an einen anderen Namen gebunden):
 
 ```pycon
 >>> import fibo as fib
@@ -166,8 +125,7 @@ anderen Namen gebunden):
 0 1 1 2 3 5 8 13 21 34 55 89 144 233 377
 ```
 
-Damit wird das Modul auf die gleiche Weise importiert wie mit `import fibo`. Der einzige Unterschied ist, dass es
-als `fib` verfügbar ist. Dies kann auch verwendet werden, wenn man `from` benutzt:
+Damit wird das Modul auf die gleiche Weise importiert wie mit `import fibo`. Der einzige Unterschied ist, dass es als `fib` verfügbar ist. Dies kann auch verwendet werden, wenn man `from` benutzt:
 
 ```pycon
 >>> from fibo import fib as fibonacci
@@ -175,9 +133,7 @@ als `fib` verfügbar ist. Dies kann auch verwendet werden, wenn man `from` benut
 0 1 1 2 3 5 8 13 21 34 55 89 144 233 377
 ```
 
-Aus Effizienzgründen wird jedes Modul nur einmal pro Interpreter-Sitzung importiert. Wenn man also sein Modul ändert,
-muss man den Interpreter neu starten - oder, wenn es nur ein Modul ist, das man interaktiv testen will, verwendet
-man `importlib.reload`, z.B. `import importlib;importlib.reload(modulname)`.
+Aus Effizienzgründen wird jedes Modul nur einmal pro Interpreter-Sitzung importiert. Wenn man also sein Modul ändert, muss man den Interpreter neu starten - oder, wenn es nur ein Modul ist, das man interaktiv testen will, verwendet man `importlib.reload`, z.B. `import importlib;importlib.reload(modulname)`.
 
 ### Module als Skript ausführen
 
@@ -187,8 +143,7 @@ Wenn man ein Python-Modul wie folgt aufruft
 python3 scriptname.py <arguments>
 ```
 
-wird - sofern vorhanden - ausführbarer Code auf oberster Ebene des Moduls ausgeführt. Beispiel am folgenden Skript
-names `square.py`:
+wird - sofern vorhanden - ausführbarer Code auf oberster Ebene des Moduls ausgeführt. Beispiel am folgenden Skript names `square.py`:
 
 ```python
 import sys
@@ -215,8 +170,7 @@ Wird das Skript wie folgt aufgerufen
 python square.py 5
 ```
 
-liefert es das Quadrat von 5 zurück. Würde man keine Zahl als Argument angeben, würde das Skript mit 10 als Defaultwert
-rechnen.
+liefert es das Quadrat von 5 zurück. Würde man keine Zahl als Argument angeben, würde das Skript mit 10 als Defaultwert rechnen.
 
 Der Code ab `if len(...)` steht auf oberster Ebene des Moduls und wird somit auch beim Import des Skripts ausgeführt:
 
@@ -249,93 +203,49 @@ if __name__ == "__main__":
     print(f'The square of {number} is {result}')
 ```
 
-Führt man ein Skript aus, wird `__name__` auf `"__main__"` gesetzt (zur Erinnerung: beim Import als Modul ist `__name__`
-gleich dem Dateinamen des Skripts). Dies wird mit der `if` Bedingung geprüft. Wenn `__name__` gleich `"__main__"` ist,
-wird der folgende Code ausgeführt. Bei einem Import ist das dann nicht der Fall. So kann man die Datei sowohl als Skript
-als auch als importierbares Modul verwenden:
+Führt man ein Skript aus, wird `__name__` auf `"__main__"` gesetzt (zur Erinnerung: beim Import als Modul ist `__name__` gleich dem Dateinamen des Skripts). Dies wird mit der `if` Bedingung geprüft. Wenn `__name__` gleich `"__main__"` ist, wird der folgende Code ausgeführt. Bei einem Import ist das dann nicht der Fall. So kann man die Datei sowohl als Skript als auch als importierbares Modul verwenden:
 
 ```pycon
 >>> import square
 >>>
 ```
 
-Dies wird häufig verwendet, um eine Benutzeroberfläche für ein Modul bereitzustellen oder zu Testzwecken (wenn das Modul
-als Skript ausgeführt wird, wird eine Testsuite ausgeführt).
+Dies wird häufig verwendet, um eine Benutzeroberfläche für ein Modul bereitzustellen oder zu Testzwecken (wenn das Modul als Skript ausgeführt wird, wird eine Testsuite ausgeführt).
 
 ### Suchpfad für Module
 
-Wenn ein Modul namens `spam` importiert wird, sucht der Interpreter zuerst nach einem eingebauten Modul mit diesem
-Namen. Diese Modulnamen sind in `sys.builtin_module_names` aufgelistet (*Hinweis*: dies sind *nicht* alle Module, die
-eine Python Standardinstallation mitbringt, sondern deutlich weniger!). Wenn es dort nicht gefunden wird, sucht der
-Interpreter nach einer Datei mit dem Namen `spam.py` in einer Liste von Verzeichnissen, die durch die
-Variable `sys.path` angegeben wird. `sys.path` wird von den folgenden Orten aus initialisiert:
+Wenn ein Modul namens `spam` importiert wird, sucht der Interpreter zuerst nach einem eingebauten Modul mit diesem Namen. Diese Modulnamen sind in `sys.builtin_module_names` aufgelistet (*Hinweis*: dies sind *nicht* alle Module, die eine Python Standardinstallation mitbringt, sondern deutlich weniger!). Wenn es dort nicht gefunden wird, sucht der Interpreter nach einer Datei mit dem Namen `spam.py` in einer Liste von Verzeichnissen, die durch die Variable `sys.path` angegeben wird. `sys.path` wird von den folgenden Orten aus initialisiert:
 
 * Das Verzeichnis, das das Eingabeskript enthält (oder das aktuelle Verzeichnis, wenn keine Datei angegeben ist).
-* Die Umgebungsvariable [PYTHONPATH](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONPATH) (eine Liste von
-  Verzeichnisnamen, mit der gleichen Syntax wie die Shell-Variable `PATH`).
-* Die installationsabhängige Voreinstellung (per Konvention einschließlich eines `site-packages`-Verzeichnisses, das
-  vom [site](https://docs.python.org/3/library/site.html#module-site) Modul verwaltet wird).
+* Die Umgebungsvariable [PYTHONPATH](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONPATH) (eine Liste von Verzeichnisnamen, mit der gleichen Syntax wie die Shell-Variable `PATH`).
+* Die installationsabhängige Voreinstellung (per Konvention einschließlich eines `site-packages`-Verzeichnisses, das vom [site](https://docs.python.org/3/library/site.html#module-site) Modul verwaltet wird).
 
-Weiterführende Informationen sind in der Python-Dokumentation
-unter [The initialization of the sys.path module search path](https://docs.python.org/3/library/sys_path_init.html#sys-path-init)
-zu finden.
+Weiterführende Informationen sind in der Python-Dokumentation unter [The initialization of the sys.path module search path](https://docs.python.org/3/library/sys_path_init.html#sys-path-init) zu finden.
 
-*Hinweis*: Auf Dateisystemen, die Symlinks unterstützen, wird das Verzeichnis, das das Eingabeskript enthält, bestimmt,
-nachdem der Symlink verfolgt wurde. Mit anderen Worten: Das Verzeichnis, das den Symlink enthält, wird *nicht* zum
-Modulsuchpfad hinzugefügt.
+*Hinweis*: Auf Dateisystemen, die Symlinks unterstützen, wird das Verzeichnis, das das Eingabeskript enthält, bestimmt, nachdem der Symlink verfolgt wurde. Mit anderen Worten: Das Verzeichnis, das den Symlink enthält, wird *nicht* zum Modulsuchpfad hinzugefügt.
 
-Nach der Initialisierung können Python-Programme `sys.path` ändern. Das Verzeichnis, das das auszuführende Skript
-enthält, wird an den Anfang des Suchpfades gesetzt, noch vor dem Pfad der Standardbibliothek. Das bedeutet, dass Skripte
-in diesem Verzeichnis anstelle von gleichnamigen Modulen im Bibliotheksverzeichnis geladen würden. Das führt in der
-Regel zu verwirrenden Fehlermeldungen, gerade bei Einsteigern. Von daher sollte man seinen Skripten immer eigenständige
-Namen geben, die nicht identisch mit den Namen von Standardmodulen bzw. zu importierenden Modulen sind.
+Nach der Initialisierung können Python-Programme `sys.path` ändern. Das Verzeichnis, das das auszuführende Skript enthält, wird an den Anfang des Suchpfades gesetzt, noch vor dem Pfad der Standardbibliothek. Das bedeutet, dass Skripte in diesem Verzeichnis anstelle von gleichnamigen Modulen im Bibliotheksverzeichnis geladen würden. Das führt in der Regel zu verwirrenden Fehlermeldungen, gerade bei Einsteigern. Von daher sollte man seinen Skripten immer eigenständige Namen geben, die nicht identisch mit den Namen von Standardmodulen bzw. zu importierenden Modulen sind.
 
 ### kompilierte Python Dateien
 
-Um das Laden von Modulen zu beschleunigen, speichert Python ein zu Python Bytecode kompilierte Version jedes Moduls
-im `__pycache__` Verzeichnis unter dem Namen `module.{version}.pyc`, wobei die Version das Format der kompilierten Datei
-kodiert. Sie enthält im Allgemeinen die Python-Versionsnummer. Zum Beispiel würde in CPython 3.9 die kompilierte Version
-von spam.py als `__pycache__/spam.cpython-39.pyc` zwischengespeichert werden. Diese Namenskonvention ermöglicht die
-Koexistenz von kompilierten Modulen aus verschiedenen Releases und verschiedenen Python-Versionen.
+Um das Laden von Modulen zu beschleunigen, speichert Python ein zu Python Bytecode kompilierte Version jedes Moduls im `__pycache__` Verzeichnis unter dem Namen `module.{version}.pyc`, wobei die Version das Format der kompilierten Datei kodiert. Sie enthält im Allgemeinen die Python-Versionsnummer. Zum Beispiel würde in CPython 3.9 die kompilierte Version von spam.py als `__pycache__/spam.cpython-39.pyc` zwischengespeichert werden. Diese Namenskonvention ermöglicht die Koexistenz von kompilierten Modulen aus verschiedenen Releases und verschiedenen Python-Versionen.
 
-Python prüft das Änderungsdatum des Quelltextes mit der kompilierten Version, um festzustellen, ob sie veraltet ist und
-neu kompiliert werden muss. Dies ist ein völlig automatischer Prozess. Außerdem sind die kompilierten Module
-plattformunabhängig, sodass dieselbe Bibliothek von Systemen mit unterschiedlichen Architekturen gemeinsam genutzt
-werden kann.
+Python prüft das Änderungsdatum des Quelltextes mit der kompilierten Version, um festzustellen, ob sie veraltet ist und neu kompiliert werden muss. Dies ist ein völlig automatischer Prozess. Außerdem sind die kompilierten Module plattformunabhängig, sodass dieselbe Bibliothek von Systemen mit unterschiedlichen Architekturen gemeinsam genutzt werden kann.
 
-Python überprüft den Cache in zwei Fällen nicht. Erstens kompiliert es immer neu und speichert das Ergebnis nicht für
-das Modul, das direkt von der Kommandozeile geladen wird. Zweitens prüft es den Cache nicht, wenn es kein Quellmodul
-gibt. Um eine Nicht-Quellcode-Distribution (nur kompiliert) zu unterstützen, muss sich das kompilierte Modul im
-Quellcode-Verzeichnis befinden, und es darf kein Quellcode-Modul vorhanden sein.
+Python überprüft den Cache in zwei Fällen nicht. Erstens kompiliert es immer neu und speichert das Ergebnis nicht für das Modul, das direkt von der Kommandozeile geladen wird. Zweitens prüft es den Cache nicht, wenn es kein Quellmodul gibt. Um eine Nicht-Quellcode-Distribution (nur kompiliert) zu unterstützen, muss sich das kompilierte Modul im Quellcode-Verzeichnis befinden, und es darf kein Quellcode-Modul vorhanden sein.
 
 Einige Expertentipps:
 
-* Man kann die Optionen `-O` oder `-OO` auf dem Python-Befehl verwenden, um die Größe eines kompilierten Moduls zu
-  reduzieren. Der Schalter `-O` entfernt `assert` Anweisungen, der Schalter `-OO` entfernt sowohl Assert-Anweisungen als
-  auch `__doc__` Zeichenketten. Da einige Programme darauf angewiesen sind, dass diese zur Verfügung stehen, sollte man
-  diese Option nur verwenden, wenn man weiß, was man tut. "Optimierte" Module haben ein `opt-` Tag und sind
-  normalerweise kleiner. Zukünftige Versionen könnten die Auswirkungen der Optimierung ändern.
-* Ein Programm läuft nicht schneller, wenn es aus einer `.pyc` Datei anstelle einer `.py` Datei gelesen wird. Das
-  Einzige, was an `.pyc` Dateien schneller ist, ist die Geschwindigkeit, mit der sie geladen werden.
-* Das Modul [compileall](https://docs.python.org/3/library/compileall.html#module-compileall) kann .pyc Dateien für alle
-  Module in einem Verzeichnis erstellen.
-* Es gibt mehr Details über diesen Prozess, einschließlich Entscheidungsbaums, in
-  der [PEP3147](https://peps.python.org/pep-3147/).
+* Man kann die Optionen `-O` oder `-OO` auf dem Python-Befehl verwenden, um die Größe eines kompilierten Moduls zu reduzieren. Der Schalter `-O` entfernt `assert` Anweisungen, der Schalter `-OO` entfernt sowohl Assert-Anweisungen als auch `__doc__` Zeichenketten. Da einige Programme darauf angewiesen sind, dass diese zur Verfügung stehen, sollte man diese Option nur verwenden, wenn man weiß, was man tut. "Optimierte" Module haben ein `opt-` Tag und sind normalerweise kleiner. Zukünftige Versionen könnten die Auswirkungen der Optimierung ändern.
+* Ein Programm läuft nicht schneller, wenn es aus einer `.pyc` Datei anstelle einer `.py` Datei gelesen wird. Das Einzige, was an `.pyc` Dateien schneller ist, ist die Geschwindigkeit, mit der sie geladen werden.
+* Das Modul [compileall](https://docs.python.org/3/library/compileall.html#module-compileall) kann .pyc Dateien für alle Module in einem Verzeichnis erstellen.
+* Es gibt mehr Details über diesen Prozess, einschließlich Entscheidungsbaums, in der [PEP3147](https://peps.python.org/pep-3147/).
 
 ## Standard Module
 
-Python wird mit einer relativ umfangreichen Bibliothek von Standardmodulen ausgeliefert, die in
-der [Python Library Reference](https://docs.python.org/3/library/index.html) beschrieben sind. Einige Module sind in
-dem Interpreter eingebaut. Diese ermöglichen den Zugriff auf Operationen, die nicht Teil des Kerns der Sprache sind, 
-aber dennoch eingebaut sind, entweder aus Gründen der Effizienz oder um den Zugriff auf Betriebssystemprimitive wie
-Systemaufrufe zu ermöglichen.
+Python wird mit einer relativ umfangreichen Bibliothek von Standardmodulen ausgeliefert, die in der [Python Library Reference](https://docs.python.org/3/library/index.html) beschrieben sind. Einige Module sind in dem Interpreter eingebaut. Diese ermöglichen den Zugriff auf Operationen, die nicht Teil des Kerns der Sprache sind, aber dennoch eingebaut sind, entweder aus Gründen der Effizienz oder um den Zugriff auf Betriebssystemprimitive wie Systemaufrufe zu ermöglichen.
 
-Die Menge solcher Module ist eine Konfigurationsoption, die auch von der zugrunde liegenden Plattform abhängt. Das
-Modul `winreg` ist beispielsweise nur auf Windows-Systemen verfügbar. Ein Modul verdient besondere
-Aufmerksamkeit: [sys](https://docs.python.org/3/library/sys.html#module-sys), das in jeden Python-Interpreter eingebaut
-ist. Die Variablen `sys.ps1` und `sys.ps2` definieren beispielsweise die Zeichenketten, die als primäre und sekundäre
-Prompts verwendet werden. Diese beiden Variablen sind nur allerdings definiert, wenn sich der Interpreter im
-interaktiven Modus befindet.
+Die Menge solcher Module ist eine Konfigurationsoption, die auch von der zugrunde liegenden Plattform abhängt. Das Modul `winreg` ist beispielsweise nur auf Windows-Systemen verfügbar. Ein Modul verdient besondere Aufmerksamkeit: [sys](https://docs.python.org/3/library/sys.html#module-sys), das in jeden Python-Interpreter eingebaut ist. Die Variablen `sys.ps1` und `sys.ps2` definieren beispielsweise die Zeichenketten, die als primäre und sekundäre Prompts verwendet werden. Diese beiden Variablen sind nur allerdings definiert, wenn sich der Interpreter im interaktiven Modus befindet.
 
 ```pycon
 >>> import sys
@@ -349,9 +259,7 @@ Yuck!
 C>
 ```
 
-Die Variable `sys.path` ist eine Liste von Strings, die den Suchpfad des Interpreters für Module bestimmt. Sie wird mit
-einem Standardpfad initialisiert, der aus der Umgebungsvariablen `PYTHONPATH` entnommen wird, oder aus einer eingebauten
-Vorgabe, wenn `PYTHONPATH` nicht gesetzt ist. Man kann ihn mit Standard-Listenoperationen ändern:
+Die Variable `sys.path` ist eine Liste von Strings, die den Suchpfad des Interpreters für Module bestimmt. Sie wird mit einem Standardpfad initialisiert, der aus der Umgebungsvariablen `PYTHONPATH` entnommen wird, oder aus einer eingebauten Vorgabe, wenn `PYTHONPATH` nicht gesetzt ist. Man kann ihn mit Standard-Listenoperationen ändern:
 
 ```pycon
 >>> import sys
@@ -360,8 +268,7 @@ Vorgabe, wenn `PYTHONPATH` nicht gesetzt ist. Man kann ihn mit Standard-Listenop
 
 ## die dir() Funktion
 
-Die eingebaute Funktion [dir](https://docs.python.org/3/library/functions.html#dir) wird verwendet, um herauszufinden,
-welche Namen ein Modul definiert. Sie gibt eine sortierte Liste von Namen innerhalb des Moduls zurück:
+Die eingebaute Funktion [dir](https://docs.python.org/3/library/functions.html#dir) wird verwendet, um herauszufinden, welche Namen ein Modul definiert. Sie gibt eine sortierte Liste von Namen innerhalb des Moduls zurück:
 
 ```pycon
 >>> import fibo, sys
@@ -401,12 +308,9 @@ Ohne Argumente listet `dir` die Namen auf, die derzeit definiert sind:
 ['__builtins__', '__name__', 'a', 'fib', 'fibo', 'sys']
 ```
 
-Zu beachten ist, dass hier alle Arten von Namen aufgeführt sind: Variablen, Module, Funktionen usw. `dir(Modulname)`
-kann auch praktisch sein, wenn man ein Modul importiert hat, aber vergessen hat, welche Funktionen, Variablen etc darin
-eigentlich entahlten sind.
+Zu beachten ist, dass hier alle Arten von Namen aufgeführt sind: Variablen, Module, Funktionen usw. `dir(Modulname)` kann auch praktisch sein, wenn man ein Modul importiert hat, aber vergessen hat, welche Funktionen, Variablen etc darin eigentlich enthalten sind.
 
-In `dir` sind die Namen der eingebauten Funktionen und Variablen nicht aufgeführt. Wenn man eine Liste dieser Funktionen
-und Variablen wünscht, muss man das Standardmodul `builtins` importieren und dafür `dir()` aufrufen:
+In `dir` sind die Namen der eingebauten Funktionen und Variablen nicht aufgeführt. Wenn man eine Liste dieser Funktionen und Variablen wünscht, muss man das Standardmodul `builtins` importieren und dafür `dir()` aufrufen:
 
 ```pycon
 >>> import builtins
@@ -444,20 +348,9 @@ und Variablen wünscht, muss man das Standardmodul `builtins` importieren und da
 
 ## Pakete
 
-Pakete sind eine Möglichkeit, den Modul-Namensraum von Python durch die Verwendung von "gepunkteten Modulnamen" zu
-strukturieren. Zum Beispiel bezeichnet der Modulname `A.B` ein Submodul namens `B` in einem Paket namens `A`. Genauso
-wie die Verwendung von Modulen die Autoren verschiedener Module davor bewahrt, sich um die Namen der globalen Variablen
-des jeweils anderen kümmern zu müssen, erspart die Verwendung von gepunkteten Modulnamen den Autoren von Paketen mit
-mehreren Modulen wie NumPy oder Pillow, sich um die Namen der Module des jeweils anderen kümmern zu müssen.
+Pakete sind eine Möglichkeit, den Modul-Namensraum von Python durch die Verwendung von "gepunkteten Modulnamen" zu strukturieren. Zum Beispiel bezeichnet der Modulname `A.B` ein Submodul namens `B` in einem Paket namens `A`. Genauso wie die Verwendung von Modulen die Autoren verschiedener Module davor bewahrt, sich um die Namen der globalen Variablen des jeweils anderen kümmern zu müssen, erspart die Verwendung von gepunkteten Modulnamen den Autoren von Paketen mit mehreren Modulen wie NumPy oder Pillow, sich um die Namen der Module des jeweils anderen kümmern zu müssen.
 
-Angenommen, man will eine Sammlung von Modulen (ein "Paket") für die einheitliche Handhabung von Tondateien und Tondaten
-entwerfen. Es gibt viele verschiedene Tondateiformate (in der Regel an der Dateierweiterung zu erkennen, z.
-B. `.wav`, `.aiff`, `.mp3`), sodass man möglicherweise eine wachsende Sammlung von Modulen für die Konvertierung
-zwischen den verschiedenen Dateiformaten erstellen und pflegen muss. Außerdem gibt es viele verschiedene Operationen,
-die man mit den Klangdaten durchführen möchte (z. B. Abmischen, Hinzufügen von Echo, Anwenden einer Equalizer-Funktion,
-Erzeugen eines künstlichen Stereoeffekts usw.), sodass man zusätzlich eine nicht enden wollenden Anzahl von Modulen zur
-Durchführung dieser Operationen schreiben müsste. Hier ist eine mögliche Struktur für das Paket (ausgedrückt in Form
-eines hierarchischen Dateisystems):
+Angenommen, man will eine Sammlung von Modulen (ein "Paket") für die einheitliche Handhabung von Tondateien und Tondaten entwerfen. Es gibt viele verschiedene Tondateiformate (in der Regel an der Dateierweiterung zu erkennen, z.B. `.wav`, `.aiff`, `.mp3`), sodass man möglicherweise eine wachsende Sammlung von Modulen für die Konvertierung zwischen den verschiedenen Dateiformaten erstellen und pflegen muss. Außerdem gibt es viele verschiedene Operationen, die man mit den Klangdaten durchführen möchte (z. B. Abmischen, Hinzufügen von Echo, Anwenden einer Equalizer-Funktion, Erzeugen eines künstlichen Stereoeffekts usw.), sodass man zusätzlich eine nicht enden wollenden Anzahl von Modulen zur Durchführung dieser Operationen schreiben müsste. Hier ist eine mögliche Struktur für das Paket (ausgedrückt in Form eines hierarchischen Dateisystems):
 
 ```
    sound/                          Top-level package
@@ -485,14 +378,9 @@ eines hierarchischen Dateisystems):
                  ...
 ```
 
-Beim Importieren des Pakets durchsucht Python die Verzeichnisse in `sys.path` auf der Suche nach dem Unterverzeichnis
-des Pakets.
+Beim Importieren des Pakets durchsucht Python die Verzeichnisse in `sys.path` auf der Suche nach dem Unterverzeichnis des Pakets.
 
-Die `__init__.py`-Dateien werden benötigt, damit Python Verzeichnisse, die die Datei enthalten, als Pakete behandelt (es
-sei denn, es wird ein "Namensraumpaket" verwendet, eine relativ fortgeschrittene Funktion). Dies verhindert, dass
-Verzeichnisse mit einem gemeinsamen Namen, wie `string`, ungewollt gültige Module verstecken, die später auf dem
-Modulsuchpfad auftauchen. Im einfachsten Fall kann `__init__.py` einfach eine leere Datei sein, aber sie kann auch
-Initialisierungscode für das Paket ausführen oder die Variable `__all__` setzen, die später beschrieben wird.
+Die `__init__.py`-Dateien werden benötigt, damit Python Verzeichnisse, die die Datei enthalten, als Pakete behandelt (es sei denn, es wird ein "Namensraumpaket" verwendet, eine relativ fortgeschrittene Funktion). Dies verhindert, dass Verzeichnisse mit einem gemeinsamen Namen, wie `string`, ungewollt gültige Module verstecken, die später auf dem Modulsuchpfad auftauchen. Im einfachsten Fall kann `__init__.py` einfach eine leere Datei sein, aber sie kann auch Initialisierungscode für das Paket ausführen oder die Variable `__all__` setzen, die später beschrieben wird.
 
 Benutzer des Pakets können einzelne Module aus dem Paket importieren, wie zum Beispiel:
 
@@ -512,8 +400,7 @@ Ein alternativer Weg zum Importieren von Submodulen ist:
 from sound.effects import echo
 ```
 
-Dies lädt auch das Submodul `echo` und macht es ohne sein Paketpräfix verfügbar, sodass es wie folgt verwendet werden
-kann:
+Dies lädt auch das Submodul `echo` und macht es ohne sein Paketpräfix verfügbar, sodass es wie folgt verwendet werden kann:
 
 ```python
 echo.echofilter(input, output, delay=0.7, atten=4)
@@ -531,41 +418,23 @@ Dies lädt wiederum das Submodul `echo`, macht aber dessen Funktion `echofilter`
 echofilter(input, output, delay=0.7, atten=4)
 ```
 
-Zu beachten ist, dass bei der Verwendung von `from package import item` das Element entweder ein Untermodul (oder
-Unterpaket) des Pakets sein kann oder ein anderer im Paket definierter Name, wie eine Funktion, Klasse oder Variable.
-Die `import` Anweisung testet zuerst, ob das Element im Paket definiert ist. Wenn nicht, nimmt sie an, dass es ein Modul
-ist und versucht es zu laden. Wenn es nicht gefunden wird, wird eine `ImportError` Ausnahme ausgelöst.
+Zu beachten ist, dass bei der Verwendung von `from package import item` das Element entweder ein Untermodul (oder Unterpaket) des Pakets sein kann oder ein anderer im Paket definierter Name, wie eine Funktion, Klasse oder Variable. Die `import` Anweisung testet zuerst, ob das Element im Paket definiert ist. Wenn nicht, nimmt sie an, dass es ein Modul ist und versucht es zu laden. Wenn es nicht gefunden wird, wird eine `ImportError` Ausnahme ausgelöst.
 
-Im Gegensatz dazu muss bei einer Syntax wie `import item.subitem.subsubitem` jedes Element außer dem letzten ein Paket
-sein. Das letzte Element kann ein Modul oder ein Paket sein, aber keine Klasse, Funktion oder Variable, die im
-vorherigen Element definiert ist.
+Im Gegensatz dazu muss bei einer Syntax wie `import item.subitem.subsubitem` jedes Element außer dem letzten ein Paket sein. Das letzte Element kann ein Modul oder ein Paket sein, aber keine Klasse, Funktion oder Variable, die im vorherigen Element definiert ist.
 
 ### Sternchen-Importe aus einem Paket
 
-Was passiert nun, wenn der Benutzer `from sound.effects import *` schreibt? Idealerweise würde man hoffen, dass Python
-irgendwie das Dateisystem durchsucht und herausfindet, welche Untermodule im Paket vorhanden sind und sie alle
-importiert. Dies könnte sehr lange dauern und der Import von Untermodulen könnte unerwünschte Nebeneffekte haben, die
-nur auftreten sollten, wenn das Untermodul explizit importiert wird.
+Was passiert nun, wenn der Benutzer `from sound.effects import *` schreibt? Idealerweise würde man hoffen, dass Python irgendwie das Dateisystem durchsucht und herausfindet, welche Untermodule im Paket vorhanden sind und sie alle importiert. Dies könnte sehr lange dauern und der Import von Untermodulen könnte unerwünschte Nebeneffekte haben, die nur auftreten sollten, wenn das Untermodul explizit importiert wird.
 
-Die Lösung besteht darin, dass der Paketautor einen expliziten Index des Pakets bereitstellt. Die `import` Anweisung
-verwendet die folgende Konvention: Wenn der `__init__.py` Code eines Pakets eine Liste namens `__all__` definiert, wird
-diese als die Liste der Modulnamen angesehen, die importiert werden sollen, wenn `from Package import *` aufgerufen
-wird. Es ist Sache des Paketautors, diese Liste aktuell zu halten, wenn eine neue Version des Pakets veröffentlicht
-wird. Paketautoren können auch entscheiden, dies nicht zu unterstützen, wenn sie keinen Nutzen für den Import von
-Sternchen-Importe aus ihrem Paket sehen. Zum Beispiel könnte die Datei `sound/effects/__init__.py` den folgenden Code
-enthalten:
+Die Lösung besteht darin, dass der Paketautor einen expliziten Index des Pakets bereitstellt. Die `import` Anweisung verwendet die folgende Konvention: Wenn der `__init__.py` Code eines Pakets eine Liste namens `__all__` definiert, wird diese als die Liste der Modulnamen angesehen, die importiert werden sollen, wenn `from Package import *` aufgerufen wird. Es ist Sache des Paketautors, diese Liste aktuell zu halten, wenn eine neue Version des Pakets veröffentlicht wird. Paketautoren können auch entscheiden, dies nicht zu unterstützen, wenn sie keinen Nutzen für den Import von Sternchen-Importe aus ihrem Paket sehen. Zum Beispiel könnte die Datei `sound/effects/__init__.py` den folgenden Code enthalten:
 
 ```python
 __all__ = ["echo", "surround", "reverse"]
 ```
 
-Das würde bedeuten, dass `from sound.effects import *` die drei genannten Untermodule des `sound.effects` Pakets
-importieren würde.
+Das würde bedeuten, dass `from sound.effects import *` die drei genannten Untermodule des `sound.effects` Pakets importieren würde.
 
-Zu beachten ist, dass Untermodule durch lokal definierte Namen überschattet werden können. Wenn man zum Beispiel
-eine `reverse` Funktion in die Datei `sound/effects/__init__.py` hinzufügt, würde der
-Aufruf `from sound.effects import *` nur die beiden Submodule `echo` und `surround` importieren, aber *nicht*
-das `reverse` Submodul, da es von der lokal definierten `reverse` Funktion überschattet wird:
+Zu beachten ist, dass Untermodule durch lokal definierte Namen überschattet werden können. Wenn man zum Beispiel eine `reverse` Funktion in die Datei `sound/effects/__init__.py` hinzufügt, würde der Aufruf `from sound.effects import *` nur die beiden Submodule `echo` und `surround` importieren, aber *nicht* das `reverse` Submodul, da es von der lokal definierten `reverse` Funktion überschattet wird:
 
 ```python
 __all__ = [
@@ -579,12 +448,7 @@ def reverse(msg: str):  # <-- dieser Name überschattet das 'reverse.py' Submodu
     return msg[::-1]  # wenn 'from sound.effects import *' aufgerufen wird
 ```
 
-Wenn ``__all__`` nicht definiert ist, importiert die Anweisung `from sound.effects import *` *nicht* alle Untermodule
-aus dem Paket `sound.effects` in den aktuellen Namensraum. Sie stellt nur sicher, dass das Paket `sound.effects`
-importiert wurde (und führt möglicherweise jeglichen Initialisierungscode in `__init__.py` aus) und importiert dann alle
-Namen, die im Paket definiert sind. Dies schließt alle Namen ein, die durch `__init__.py` definiert (und Untermodule
-explizit geladen) wurden. Es schließt auch alle Untermodule des Pakets ein, die explizit durch vorherige `import`
-Anweisungen geladen wurden. Betrachtet man den folgenden Code:
+Wenn ``__all__`` nicht definiert ist, importiert die Anweisung `from sound.effects import *` *nicht* alle Untermodule aus dem Paket `sound.effects` in den aktuellen Namensraum. Sie stellt nur sicher, dass das Paket `sound.effects` importiert wurde (und führt möglicherweise jeglichen Initialisierungscode in `__init__.py` aus) und importiert dann alle Namen, die im Paket definiert sind. Dies schließt alle Namen ein, die durch `__init__.py` definiert (und Untermodule explizit geladen) wurden. Es schließt auch alle Untermodule des Pakets ein, die explizit durch vorherige `import` Anweisungen geladen wurden. Betrachtet man den folgenden Code:
 
 ```python
 import sound.effects.echo
@@ -592,28 +456,17 @@ import sound.effects.surround
 from sound.effects import *
 ```
 
-In diesem Beispiel werden die Module `echo` und `surround` in den aktuellen Namespace importiert, weil sie im
-Paket `sound.effects` definiert sind, wenn die Anweisung `from...import` ausgeführt wird. Dies funktioniert auch,
-wenn `__all__` definiert ist.
+In diesem Beispiel werden die Module `echo` und `surround` in den aktuellen Namespace importiert, weil sie im Paket `sound.effects` definiert sind, wenn die Anweisung `from...import` ausgeführt wird. Dies funktioniert auch, wenn `__all__` definiert ist.
 
-Obwohl bestimmte Module so konzipiert sind, dass sie nur Namen exportieren, die bestimmten Mustern folgen, wenn
-Sie `import *` verwenden, wird `import *` nach wie vor als schlechter Stil angesehen und sollte von daher im eigenen
-Code vermieden werden.
+Obwohl bestimmte Module so konzipiert sind, dass sie nur Namen exportieren, die bestimmten Mustern folgen, wenn Sie `import *` verwenden, wird `import *` nach wie vor als schlechter Stil angesehen und sollte von daher im eigenen Code vermieden werden.
 
-Aber es ist nicht falsch, `from package import specific_submodule` zu verwenden! Dies ist sogar die empfohlene
-Schreibweise, es sei denn, das importierende Modul muss Submodule mit demselben Namen aus verschiedenen Paketen
-verwenden.
+Aber es ist nicht falsch, `from package import specific_submodule` zu verwenden! Dies ist sogar die empfohlene Schreibweise, es sei denn, das importierende Modul muss Submodule mit demselben Namen aus verschiedenen Paketen verwenden.
 
 ### Intra-Paket Referenzen
 
-Wenn Pakete in Unterpakete strukturiert sind (wie das Paket `sound` im Beispiel oben), kann man absolute Importe
-verwenden, um auf Untermodule von Geschwisterpaketen zu verweisen. Wenn zum Beispiel das Modul `sound.filters.vocoder`
-das Modul `echo` aus dem Paket `sound.effects` verwenden muss, kann es `from sound.effects import echo` für den Import
-verwenden.
+Wenn Pakete in Unterpakete strukturiert sind (wie das Paket `sound` im Beispiel oben), kann man absolute Importe verwenden, um auf Untermodule von Geschwisterpaketen zu verweisen. Wenn zum Beispiel das Modul `sound.filters.vocoder` das Modul `echo` aus dem Paket `sound.effects` verwenden muss, kann es `from sound.effects import echo` für den Import verwenden.
 
-Man kann auch relative Importe schreiben, mit der Form der Import-Anweisung "from module import name". Diese Importe
-verwenden führende Punkte, um die aktuellen und übergeordneten Pakete anzuzeigen, die am relativen Import beteiligt
-sind. Aus dem Modul `surround` heraus könnte man z.B. verwenden
+Man kann auch relative Importe schreiben, mit der Form der Import-Anweisung "from module import name". Diese Importe verwenden führende Punkte, um die aktuellen und übergeordneten Pakete anzuzeigen, die am relativen Import beteiligt sind. Aus dem Modul `surround` heraus könnte man z.B. verwenden
 
 ```python
 from . import echo
@@ -621,19 +474,13 @@ from .. import formats
 from ..filters import equalizer
 ```
 
-Zu beachten ist, dass sich relative Importe auf den Namen des aktuellen Moduls beziehen. Da der Name des Hauptmoduls
-immer `"__main__"` ist, müssen Module, die als Hauptmodul einer Python-Anwendung verwendet werden sollen, immer absolute
-Importe verwenden.
+Zu beachten ist, dass sich relative Importe auf den Namen des aktuellen Moduls beziehen. Da der Name des Hauptmoduls immer `"__main__"` ist, müssen Module, die als Hauptmodul einer Python-Anwendung verwendet werden sollen, immer absolute Importe verwenden.
 
 ### Pakete in mehreren Verzeichnissen
 
-Pakete unterstützen ein weiteres spezielles Attribut, `__path__`. Dieses wird als Liste initialisiert, die den Namen des
-Verzeichnisses enthält, das die `__init__.py` des Pakets enthält, bevor der Code in dieser Datei ausgeführt wird. Diese
-Variable kann geändert werden. Dies beeinflusst die zukünftige Suche nach Modulen und Unterpaketen, die in dem Paket
-enthalten sind.
+Pakete unterstützen ein weiteres spezielles Attribut, `__path__`. Dieses wird als Liste initialisiert, die den Namen des Verzeichnisses enthält, das die `__init__.py` des Pakets enthält, bevor der Code in dieser Datei ausgeführt wird. Diese Variable kann geändert werden. Dies beeinflusst die zukünftige Suche nach Modulen und Unterpaketen, die in dem Paket enthalten sind.
 
-Obwohl diese Funktion nicht oft benötigt wird, kann sie verwendet werden, um die Menge der in einem Paket gefundenen
-Module zu erweitern.
+Obwohl diese Funktion nicht oft benötigt wird, kann sie verwendet werden, um die Menge der in einem Paket gefundenen Module zu erweitern.
 
 ***
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,12 +1,25 @@
 # Module
 
-Wenn man den Python-Interpreter verlässt und ihn erneut aufrufen, gehen die vorgenommenen Definitionen (Funktionen, Variablen etc.) verloren. Wenn man also ein etwas längeres Programm schreiben möchte, ist es besser, einen Texteditor zu verwenden, um die Eingabe für den Interpreter vorzubereiten und diesen stattdessen mit der Programmdatei als Eingabe zu starten. Dies wird als Erstellen eines Skripts bzw. Programms bezeichnet (Anmerkung zur Vermeidung von Missverständnissen: Python-Skript und Python-Programm sind synonym, also dasselbe: eine Datei, die Python Code enthält). Wenn das Programm länger wird, möchten man es vielleicht in mehrere Dateien aufteilen, um die Wartung und Pflege zu erleichtern. Vielleicht möchten man auch eine praktische Funktion, die man geschrieben hat, in mehreren Programmen verwenden, ohne den Code in jedes Programm hinein kopieren zu müssen.
+Wird der Python-Interpreter verlassen und erneut aufgerufen, gehen die vorgenommenen Definitionen (Funktionen, Variablen
+etc.) verloren. Schreibt man ein etwas längeres Programm, so ist es besser einen Texteditor zu verwenden, um die Eingabe
+für den Interpreter vorzubereiten und diesen stattdessen mit der Programmdatei als Eingabe zu starten. Dies wird als
+Erstellen eines Skripts bzw. Programms bezeichnet (Anmerkung zur Vermeidung von Missverständnissen: Python-Skript und
+Python-Programm sind synonym, also dasselbe: eine Datei, die Python Code enthält). Wenn das Programm länger wird, möchte
+man es vielleicht in mehrere Dateien aufteilen, um die Wartung und Pflege zu erleichtern. Vielleicht möchte man auch
+eine praktische Funktion, die man geschrieben hat, in mehreren Programmen verwenden, ohne den Code in jedes Programm
+hinein kopieren zu müssen.
 
-Um dies zu unterstützen, bietet Python eine Möglichkeit, Definitionen in einer Datei abzulegen und sie in einem Skript oder in einer interaktiven Instanz des Interpreters zu verwenden. Eine solche Datei wird als *Modul* bezeichnet. Definitionen aus einem Modul können in andere Module oder in das *Hauptmodul* (die Sammlung von Variablen, auf die man in einem Skript, das auf der obersten Ebene und im Rechnermodus ausgeführt wird, Zugriff hat) *importiert* werden.
+Um dies zu unterstützen, bietet Python eine Möglichkeit, Definitionen in einer Datei abzulegen und sie in einem Skript
+oder in einer interaktiven Instanz des Interpreters zu verwenden. Eine solche Datei wird als *Modul* bezeichnet.
+Definitionen aus einem Modul können in anderen Modulen oder in das *Hauptmodul* (die Sammlung von Variablen, auf die man
+in einem Skript, das auf der obersten Ebene und im Rechnermodus ausgeführt wird, Zugriff hat) *importiert* werden.
 
-Ein Modul ist eine Datei, die Python-Definitionen und Anweisungen enthält. Der Dateiname ist der Modulname mit der angehängten Endung `.py`.  Innerhalb eines Moduls ist der Name des Moduls (als String) als Wert der globalen Variable `__name__` verfügbar, welche automatisch von Python beim Import des Moduls angelegt wird.
+Ein Modul ist eine Datei, die Python-Definitionen und Anweisungen enthält. Der Dateiname ist der Modulname mit der
+angehängten Endung `.py`. Innerhalb eines Moduls ist der Name des Moduls (als String) als Wert der globalen
+Variable `__name__` verfügbar, welche automatisch von Python beim Import des Moduls angelegt wird.
 
-Im Folgenden wird eine Datei namens `fibo.py` angelegt, welche dann als Modul importiert wird. Die Datei kann man mit seinem bevorzugten Texteditor mit folgenden Inhalt füllen:
+Im Folgenden wird eine Datei namens `fibo.py` angelegt, welche dann als Modul importiert wird. Die Datei kann man mit
+seinem bevorzugten Texteditor mit folgendem Inhalt füllen:
 
 ```python
 # Fibonacci numbers module
@@ -17,8 +30,9 @@ def fib(n):
     a, b = 0, 1
     while a < n:
         print(a, end=' ')
-        a, b = b, a+b
+        a, b = b, a + b
     print()
+
 
 def fib2(n):
     '''return Fibonacci series up to n'''
@@ -27,19 +41,26 @@ def fib2(n):
     a, b = 0, 1
     while a < n:
         result.append(a)
-        a, b = b, a+b
+        a, b = b, a + b
     return result
 ```
 
-Jetzt öffnet man den Python Interpreter im demselben Verzeichnis, in dem die Datei liegt, und führt den folgenden Befehl im Interpreter aus:
+Jetzt öffnet man den Python Interpreter in demselben Verzeichnis, in dem die Datei liegt, und führt den folgenden Befehl
+im Interpreter aus:
 
 ```python
->>> import fibo
->>>
+>> > import fibo
+>> >
 ```
-Wenn der Import erfolgreich war, ist man einfach erneut am Prompt und könnte jetzt auf die importieren Funktionen zugreifen.
 
-Was beim Import passiert: Es wird der Modulname `fibo` im aktuelle Namensraum des Python Interpreter ein. Die beiden Funktionsname aus dem `fibo` Modul werde nicht eingefügt, jedenfalls nicht direkt. Mehr zum Thema Namensräume (auf Englisch: namespace) sind in der Python Dokumentation im Abschnitt [namespace](https://docs.python.org/3/glossary.html#term-namespace) zu finden. Mehr Informationen zu Namensräumen und Gültigkeiten in Namensräumen sind im Kapitel zu [Klassen](classes.md) in diesem Tutorial zu finden.
+Wenn der Import erfolgreich war, ist man einfach erneut am Prompt und könnte jetzt auf die importieren Funktionen
+zugreifen.
+
+Was beim Import passiert: Es wird der Modulname `fibo` im aktuelle Namensraum des Python Interpreter eingefügt. 
+Die beiden Funktionsnamen aus dem `fibo` Modul werden nicht eingefügt, jedenfalls nicht direkt. 
+Mehr zum Thema Namensräume (auf Englisch: namespace) sind in der Python Dokumentation im
+Abschnitt [namespace](https://docs.python.org/3/glossary.html#term-namespace) zu finden. Mehr Informationen zu
+Namensräumen und Gültigkeiten in Namensräumen sind im Kapitel [Klassen](classes.md) in diesem Tutorial zu finden.
 
 Über den Modulnamen kann man auf die Funktionen zugreifen:
 
@@ -52,7 +73,8 @@ Was beim Import passiert: Es wird der Modulname `fibo` im aktuelle Namensraum de
 'fibo'
 ```
 
-Wenn man eine Funktion häufig verwenden möchten, kann man ihr einen lokalen Namen zuweisen - was aber eher selten notwendig ist:
+Wenn man eine Funktion häufig verwenden möchten, kann man ihr einen lokalen Namen zuweisen - was aber eher selten
+notwendig ist:
 
 ```pycon
 >>> fib = fibo.fib
@@ -60,19 +82,24 @@ Wenn man eine Funktion häufig verwenden möchten, kann man ihr einen lokalen Na
 0 1 1 2 3 5 8 13 21 34 55 89 144 233 377
 ```
 
-Ohne zu weit in die Tiefe zu gehen sei hier noch erwähnt, dass man nicht nur Funktionen wie im obigen Beispiel importieren kann, sondern alle Objekte, die auf oberster Ebene in der Datei stehen. Hätte man z.B. eine Datei `demo.py` mit folgendem Inhalt
+Ohne zu weit in die Tiefe zu gehen sei hier noch erwähnt, dass man nicht nur Funktionen wie im obigen Beispiel
+importieren kann, sondern alle Objekte, die auf oberster Ebene in der Datei stehen. Hätte man z.B. eine Datei `demo.py`
+mit folgendem Inhalt
 
 ```python
 THE_ANSWER = 42
 
+
 def say_hello_world():
     print('Hello World')
+
 
 class EmptyClass:
     pass
 ```
 
-kann man nach einem Import der Datei auf die Variable `THE_ANSWER`, die Funktion `say_hello_world` und die Klasse `EmptyClass` zugreifen:
+kann man nach einem Import der Datei auf die Variable `THE_ANSWER`, die Funktion `say_hello_world` und die
+Klasse `EmptyClass` zugreifen:
 
 ```pycon
 >>> import demo
@@ -87,13 +114,23 @@ Hello World
 
 ## mehr zu Modulen
 
-Ein Modul kann sowohl ausführbare Anweisungen als auch Funktionsdefinitionen enthalten. Diese Anweisungen dienen der Initialisierung des Moduls. Sie werden nur beim *ersten* Auftreten des Modulnamens in einer Import-Anweisung ausgeführt. Sie werden immer ausgeführt, auch wenn die Datei als Skript ausgeführt wird (dazu später in diesem Kapitel mehr).
+Ein Modul kann sowohl ausführbare Anweisungen als auch Funktionsdefinitionen enthalten. Diese Anweisungen dienen der
+Initialisierung des Moduls. Sie werden nur beim *ersten* Auftreten des Modulnamens in einer Import-Anweisung ausgeführt.
+Sie werden immer ausgeführt, auch wenn die Datei als Skript ausgeführt wird (dazu später in diesem Kapitel mehr).
 
-Jedes Modul hat seinen eigenen privaten Namensraum, der von allen im Modul definierten Funktionen als Namensraum verwendet wird. Auf diese Weise kann der Autor eines Moduls globale Variablen im Modul verwenden, ohne sich Gedanken über versehentliche Konflikte mit den globalen Variablen eines Benutzers zu machen. Andererseits kann man, wenn man weiß, was man tut, die globalen Variablen eines Moduls mit der gleichen Notation ansprechen, mit der man auf die Funktionen des Moduls verweisen: `Modname.Funktionsname`.
+Jedes Modul hat seinen eigenen privaten Namensraum, der von allen im Modul definierten Funktionen als Namensraum
+verwendet wird. Auf diese Weise kann der Autor eines Moduls globale Variablen im Modul verwenden, ohne sich Gedanken
+über versehentliche Konflikte mit den globalen Variablen eines Benutzers zu machen. Andererseits kann man, wenn man
+weiß, was man tut, die globalen Variablen eines Moduls mit der gleichen Notation ansprechen, mit der man auf die
+Funktionen des Moduls verweist: `Modulname.Funktionsname`.
 
-Module können andere Module importieren. Es ist üblich und gilt als "best practice" (ist aber nicht zwingend erforderlich), alle `import` Anweisungen an den Anfang eines Moduls (oder Skripts) zu stellen. Die importierten Modulnamen werden, wenn sie auf der obersten Ebene eines Moduls (außerhalb von Funktionen oder Klassen) stehen, dem globalen Namensraum des Moduls hinzugefügt.
+Module können andere Module importieren. Es ist üblich und gilt als "best practice" (ist aber nicht zwingend
+erforderlich), alle `import` Anweisungen an den Anfang eines Moduls (oder Skripts) zu schreiben. Die importierten
+Modulnamen werden, wenn sie auf der obersten Ebene eines Moduls (außerhalb von Funktionen oder Klassen) stehen, dem
+globalen Namensraum des Moduls hinzugefügt.
 
-Es gibt eine Variante der `import` Anweisung, die Namen aus einem Modul direkt in den Namensraum des importierenden Moduls importiert. Im Folgenden Beispiel werden die Funktionen `fib` und `fib2` aus dem Moduel `fibo` importiert:
+Es gibt eine Variante der `import` Anweisung, die Namen aus einem Modul direkt in den Namensraum des importierenden
+Moduls importiert. Im Folgenden Beispiel werden die Funktionen `fib` und `fib2` aus dem Moduel `fibo` importiert:
 
 ```pycon
 >>> from fibo import fib, fib2
@@ -101,7 +138,9 @@ Es gibt eine Variante der `import` Anweisung, die Namen aus einem Modul direkt i
 0 1 1 2 3 5 8 13 21 34 55 89 144 233 377
 ```
 
-Dadurch wird der Modulname, von dem die Importe übernommen werden, nicht in den lokalen Namensraum eingeführt. Im Beispiel ist also `fibo` also nicht definiert.
+Dadurch wird der Modulname, von dem die Importe übernommen werden, nicht in den lokalen Namensraum eingefügt. Im
+Beispiel ist also `fibo` nicht definiert. Ein vorangestelltes `fibo` um auf die Funktionen `fib` und `fib2` zuzugreifen
+ist also nicht notwendig.
 
 Es gibt auch eine Variante, um alle Namen zu importieren, die ein Modul definiert:
 
@@ -111,9 +150,15 @@ Es gibt auch eine Variante, um alle Namen zu importieren, die ein Modul definier
 >>> 0 1 1 2 3 5 8 13 21 34 55 89 144 233 377
 ```
 
-Dies importiert alle Namen außer denen, die mit einem Unterstrich (`_`) beginnen. In den meisten Fällen benutzen Python-Programmierer diese Möglichkeit nicht, da sie eine unbekannte Menge von Namen in Namensraum einbinden. Dadurch besteht auch das Risiko, dass bereits bestehend Objekte mit gleichem Namen überschrieben werden. Außerdem ist dann oft unklar, wo ein Name herkommt, was zu schlecht lesbarem Code führt. Von daher gelten diese *Sternchen Importe* als schlechter Stil und werden in vielen Fällen vermieden
+Dies importiert alle Namen außer denen, die mit einem Unterstrich (`_`) beginnen. In den meisten Fällen benutzen
+Python-Programmierer diese Möglichkeit nicht, da sie eine unbekannte Menge von Namen in Namensraum einbinden. Dadurch
+besteht das Risiko, dass bereits bestehend Objekte mit gleichem Namen überschrieben werden. Außerdem ist dann oft
+unklar, wo ein Name herkommt, was zu schlecht lesbarem Code führt. Von daher gelten diese *Sternchen Importe* als
+schlechter Stil und werden in vielen Fällen vermieden.
 
-Wenn auf den Modulname das Schlüsselwort `as` folgt, wird der Name, der auf `as` folgt, direkt an das importierte Modul gebunden. Oder anders ausgedrückt: im Namenraum, in den das Modul importiert wird, wird das Modul umbenannt (=an einen anderen Namen gebunden):
+Folgt auf dem Modulnamen das Schlüsselwort `as`, wird der Name, der auf `as` folgt, direkt an das importierte Modul
+gebunden. Oder anders ausgedrückt: im Namenraum, in den das Modul importiert wird, wird das Modul umbenannt (=an einen
+anderen Namen gebunden):
 
 ```pycon
 >>> import fibo as fib
@@ -121,7 +166,8 @@ Wenn auf den Modulname das Schlüsselwort `as` folgt, wird der Name, der auf `as
 0 1 1 2 3 5 8 13 21 34 55 89 144 233 377
 ```
 
-Damit wird das Modul auf die gleiche Weise importiert wie mit `import fibo`. Der einzige Unterschied ist, dass es als `fib` verfügbar ist. Dies kann auch verwendet werden, wenn man `from` benutzt:
+Damit wird das Modul auf die gleiche Weise importiert wie mit `import fibo`. Der einzige Unterschied ist, dass es
+als `fib` verfügbar ist. Dies kann auch verwendet werden, wenn man `from` benutzt:
 
 ```pycon
 >>> from fibo import fib as fibonacci
@@ -129,7 +175,9 @@ Damit wird das Modul auf die gleiche Weise importiert wie mit `import fibo`. Der
 0 1 1 2 3 5 8 13 21 34 55 89 144 233 377
 ```
 
-Aus Effizienzgründen wird jedes Modul nur einmal pro Interpreter-Sitzung importiert. Wenn man also sein Modul ändert, muss man den Interpreter neu starten - oder, wenn es nur ein Modul ist, das welche man interaktiv testen will, verwendet man `importlib.reload`, z.B. `import importlib;importlib.reload(modulname)``.
+Aus Effizienzgründen wird jedes Modul nur einmal pro Interpreter-Sitzung importiert. Wenn man also sein Modul ändert,
+muss man den Interpreter neu starten - oder, wenn es nur ein Modul ist, das man interaktiv testen will, verwendet
+man `importlib.reload`, z.B. `import importlib;importlib.reload(modulname)`.
 
 ### Module als Skript ausführen
 
@@ -139,15 +187,18 @@ Wenn man ein Python-Modul wie folgt aufruft
 python3 scriptname.py <arguments>
 ```
 
-wird - sofern vorhanden - ausführbarer Code auf oberster Ebene des Moduls ausgeführt. Beispiel am folgenden Skript names `square.py`:
+wird - sofern vorhanden - ausführbarer Code auf oberster Ebene des Moduls ausgeführt. Beispiel am folgenden Skript
+names `square.py`:
 
 ```python
 import sys
 
+
 def square(number):
     '''Returns the square of a given number'''
 
-    return number**2
+    return number ** 2
+
 
 if len(sys.argv) > 1:
     number = sys.argv[1]
@@ -164,9 +215,10 @@ Wird das Skript wie folgt aufgerufen
 python square.py 5
 ```
 
-liefert es das Quadrat von 5 zurück. Würde man keine Zahl als Argument angeben, würde das Skript mit 10 als Defaultwert rechnen.
+liefert es das Quadrat von 5 zurück. Würde man keine Zahl als Argument angeben, würde das Skript mit 10 als Defaultwert
+rechnen.
 
-Der Code ab `if len(...)` steht auf oberster Ebene des Moduls und würde somit auch beim Import des Skripts ausgeführt:
+Der Code ab `if len(...)` steht auf oberster Ebene des Moduls und wird somit auch beim Import des Skripts ausgeführt:
 
 ```pycon
 >>> import square
@@ -180,10 +232,12 @@ Die will man in der Regel aber nicht. Verhindern kann man es, in dem man den Cod
 ```python
 import sys
 
+
 def square(number):
     '''Returns the square of a given number'''
 
-    return number**2
+    return number ** 2
+
 
 if __name__ == "__main__":
     if len(sys.argv) > 1:
@@ -195,49 +249,93 @@ if __name__ == "__main__":
     print(f'The square of {number} is {result}')
 ```
 
-Führt man ein Skript aus, wird `__name__` auf `"__main__"` gesetzt (zur Erinnerung: beim Import als Modul ist `__name__` gleich dem Dateinamen des Skripts). Dies wird mit der `if` Bedingung geprüft. Wenn `__name__` gleich `"__main__"` ist wird der folgende Code ausgeführt. Bei einem Import ist das dann nicht der Fall. So kann man die Datei sowohl als Skript als auch als importierbares Modul verwenden:
+Führt man ein Skript aus, wird `__name__` auf `"__main__"` gesetzt (zur Erinnerung: beim Import als Modul ist `__name__`
+gleich dem Dateinamen des Skripts). Dies wird mit der `if` Bedingung geprüft. Wenn `__name__` gleich `"__main__"` ist,
+wird der folgende Code ausgeführt. Bei einem Import ist das dann nicht der Fall. So kann man die Datei sowohl als Skript
+als auch als importierbares Modul verwenden:
 
 ```pycon
 >>> import square
 >>>
 ```
 
-Dies wird häufig verwendet, um eine Benutzeroberfläche für ein Modul bereitzustellen oder zu Testzwecken (wenn das Modul als Skript ausgeführt wird, wird eine Testsuite ausgeführt).
+Dies wird häufig verwendet, um eine Benutzeroberfläche für ein Modul bereitzustellen oder zu Testzwecken (wenn das Modul
+als Skript ausgeführt wird, wird eine Testsuite ausgeführt).
 
 ### Suchpfad für Module
 
-Wenn ein Modul namens `spam` importiert wird, sucht der Interpreter zuerst nach einem eingebauten Modul mit diesem Namen. Diese Modulnamen sind in `sys.builtin_module_names` aufgelistet (*Hinweis*: dies sind *nicht* alle Module, die eine Python Standardinstallation mit bringt, sondern deutlich weniger!). Wenn es dort nicht gefunden wird, sucht der Interpreter nach einer Datei mit dem Namen `spam.py` in einer Liste von Verzeichnissen, die durch die Variable `sys.path` angegeben wird. `sys.path` wird von den folgenden Orten aus initialisiert:
+Wenn ein Modul namens `spam` importiert wird, sucht der Interpreter zuerst nach einem eingebauten Modul mit diesem
+Namen. Diese Modulnamen sind in `sys.builtin_module_names` aufgelistet (*Hinweis*: dies sind *nicht* alle Module, die
+eine Python Standardinstallation mitbringt, sondern deutlich weniger!). Wenn es dort nicht gefunden wird, sucht der
+Interpreter nach einer Datei mit dem Namen `spam.py` in einer Liste von Verzeichnissen, die durch die
+Variable `sys.path` angegeben wird. `sys.path` wird von den folgenden Orten aus initialisiert:
 
- * Das Verzeichnis, das das Eingabeskript enthält (oder das aktuelle Verzeichnis, wenn keine Datei angegeben ist).
- * Die Umgebungsvariable [PYTHONPATH](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONPATH) (eine Liste von Verzeichnisnamen, mit der gleichen Syntax wie die Shell-Variable `PATH`).
- * Die installationsabhängige Voreinstellung (per Konvention einschließlich eines `site-packages`-Verzeichnisses, das vom [site](https://docs.python.org/3/library/site.html#module-site) Modul verwaltet wird).
+* Das Verzeichnis, das das Eingabeskript enthält (oder das aktuelle Verzeichnis, wenn keine Datei angegeben ist).
+* Die Umgebungsvariable [PYTHONPATH](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONPATH) (eine Liste von
+  Verzeichnisnamen, mit der gleichen Syntax wie die Shell-Variable `PATH`).
+* Die installationsabhängige Voreinstellung (per Konvention einschließlich eines `site-packages`-Verzeichnisses, das
+  vom [site](https://docs.python.org/3/library/site.html#module-site) Modul verwaltet wird).
 
-Weiterführende Informationen sind in der Python-Dokumentation unter [The initialization of the sys.path module search path](https://docs.python.org/3/library/sys_path_init.html#sys-path-init) zu finden.
+Weiterführende Informationen sind in der Python-Dokumentation
+unter [The initialization of the sys.path module search path](https://docs.python.org/3/library/sys_path_init.html#sys-path-init)
+zu finden.
 
-*Hinweis*: Auf Dateisystemen, die Symlinks unterstützen, wird das Verzeichnis, das das Eingabeskript enthält, bestimmt, nachdem der Symlink verfolgt wurde. Mit anderen Worten: Das Verzeichnis, das den Symlink enthält, wird *nicht* zum Modulsuchpfad hinzugefügt.
+*Hinweis*: Auf Dateisystemen, die Symlinks unterstützen, wird das Verzeichnis, das das Eingabeskript enthält, bestimmt,
+nachdem der Symlink verfolgt wurde. Mit anderen Worten: Das Verzeichnis, das den Symlink enthält, wird *nicht* zum
+Modulsuchpfad hinzugefügt.
 
-Nach der Initialisierung können Python-Programme `sys.path` ändern. Das Verzeichnis, das das auszuführende Skript enthält, wird an den Anfang des Suchpfades gesetzt, noch vor dem Pfad der Standardbibliothek. Das bedeutet, dass Skripte in diesem Verzeichnis anstelle von gleichnamigen Modulen im Bibliotheksverzeichnis geladen würden. Das führt in der Regel zu verwirrenden Fehlermeldungen, gerade bei Einsteigern. Von daher sollte man seinen Skripten immer eigenständige Namen geben, die nicht identisch mit den Namen von Standardmodulen bzw. zu importierenden Modulen sind.
+Nach der Initialisierung können Python-Programme `sys.path` ändern. Das Verzeichnis, das das auszuführende Skript
+enthält, wird an den Anfang des Suchpfades gesetzt, noch vor dem Pfad der Standardbibliothek. Das bedeutet, dass Skripte
+in diesem Verzeichnis anstelle von gleichnamigen Modulen im Bibliotheksverzeichnis geladen würden. Das führt in der
+Regel zu verwirrenden Fehlermeldungen, gerade bei Einsteigern. Von daher sollte man seinen Skripten immer eigenständige
+Namen geben, die nicht identisch mit den Namen von Standardmodulen bzw. zu importierenden Modulen sind.
 
 ### kompilierte Python Dateien
 
-Um das Laden von Modulen zu beschleunigen, speichert Python ein zu Python Bytecode kompilierte Version jedes Moduls im `__pycache__` Verzeichnis unter dem Namen `module.{version}.pyc`, wobei die Version das Format der kompilierten Datei kodiert. Sie enthält im Allgemeinen die Python-Versionsnummer. Zum Beispiel würde in CPython 3.9 die kompilierte Version von spam.py als `__pycache__/spam.cpython-39.pyc`` zwischengespeichert werden. Diese Namenskonvention ermöglicht die Koexistenz von kompilierten Modulen aus verschiedenen Releases und verschiedenen Python-Versionen.
+Um das Laden von Modulen zu beschleunigen, speichert Python ein zu Python Bytecode kompilierte Version jedes Moduls
+im `__pycache__` Verzeichnis unter dem Namen `module.{version}.pyc`, wobei die Version das Format der kompilierten Datei
+kodiert. Sie enthält im Allgemeinen die Python-Versionsnummer. Zum Beispiel würde in CPython 3.9 die kompilierte Version
+von spam.py als `__pycache__/spam.cpython-39.pyc` zwischengespeichert werden. Diese Namenskonvention ermöglicht die
+Koexistenz von kompilierten Modulen aus verschiedenen Releases und verschiedenen Python-Versionen.
 
-Python prüft das Änderungsdatum des Quelltextes mit der kompilierten Version, um festzustellen, ob sie veraltet ist und neu kompiliert werden muss. Dies ist ein völlig automatischer Prozess. Außerdem sind die kompilierten Module plattformunabhängig, so dass dieselbe Bibliothek von Systemen mit unterschiedlichen Architekturen gemeinsam genutzt werden kann.
+Python prüft das Änderungsdatum des Quelltextes mit der kompilierten Version, um festzustellen, ob sie veraltet ist und
+neu kompiliert werden muss. Dies ist ein völlig automatischer Prozess. Außerdem sind die kompilierten Module
+plattformunabhängig, sodass dieselbe Bibliothek von Systemen mit unterschiedlichen Architekturen gemeinsam genutzt
+werden kann.
 
-Python überprüft den Cache in zwei Fällen nicht. Erstens kompiliert es immer neu und speichert das Ergebnis nicht für das Modul, das direkt von der Kommandozeile geladen wird. Zweitens prüft es den Cache nicht, wenn es kein Quellmodul gibt. Um eine Nicht-Quellcode-Distribution (nur kompiliert) zu unterstützen, muss sich das kompilierte Modul im Quellcode-Verzeichnis befinden, und es darf kein Quellcode-Modul vorhanden sein.
+Python überprüft den Cache in zwei Fällen nicht. Erstens kompiliert es immer neu und speichert das Ergebnis nicht für
+das Modul, das direkt von der Kommandozeile geladen wird. Zweitens prüft es den Cache nicht, wenn es kein Quellmodul
+gibt. Um eine Nicht-Quellcode-Distribution (nur kompiliert) zu unterstützen, muss sich das kompilierte Modul im
+Quellcode-Verzeichnis befinden, und es darf kein Quellcode-Modul vorhanden sein.
 
 Einige Expertentipps:
 
- * Man kann die Optionen `-O` oder `-OO` auf dem Python-Befehl verwenden, um die Größe eines kompilierten Moduls zu reduzieren. Der Schalter `-O` entfernt `assert` Anweisungen, der Schalter `-OO` entfernt sowohl Assert-Anweisungen als auch `__doc__` Zeichenketten. Da einige Programme darauf angewiesen sind, dass diese zur Verfügung stehen, sollte man diese Option nur verwenden, wenn man weiß, was man tut. "Optimierte" Module haben ein `opt-` Tag und sind normalerweise kleiner.   Zukünftige Versionen könnten die Auswirkungen der Optimierung ändern.
- * Ein Programm läuft nicht schneller, wenn es aus einer `.pyc` Datei anstelle einer `.py` Datei gelesen wird. Das Einzige, was an `.pyc` Dateien schneller ist, ist die Geschwindigkeit, mit der sie geladen werden.
- * Das Modul [compileall](https://docs.python.org/3/library/compileall.html#module-compileall) kann .pyc Dateien für alle Module in einem Verzeichnis erstellen.
- * Es gibt mehr Details über diesen Prozess, einschließlich Entscheidungsbaums, in der [PEP3147](https://peps.python.org/pep-3147/).
+* Man kann die Optionen `-O` oder `-OO` auf dem Python-Befehl verwenden, um die Größe eines kompilierten Moduls zu
+  reduzieren. Der Schalter `-O` entfernt `assert` Anweisungen, der Schalter `-OO` entfernt sowohl Assert-Anweisungen als
+  auch `__doc__` Zeichenketten. Da einige Programme darauf angewiesen sind, dass diese zur Verfügung stehen, sollte man
+  diese Option nur verwenden, wenn man weiß, was man tut. "Optimierte" Module haben ein `opt-` Tag und sind
+  normalerweise kleiner. Zukünftige Versionen könnten die Auswirkungen der Optimierung ändern.
+* Ein Programm läuft nicht schneller, wenn es aus einer `.pyc` Datei anstelle einer `.py` Datei gelesen wird. Das
+  Einzige, was an `.pyc` Dateien schneller ist, ist die Geschwindigkeit, mit der sie geladen werden.
+* Das Modul [compileall](https://docs.python.org/3/library/compileall.html#module-compileall) kann .pyc Dateien für alle
+  Module in einem Verzeichnis erstellen.
+* Es gibt mehr Details über diesen Prozess, einschließlich Entscheidungsbaums, in
+  der [PEP3147](https://peps.python.org/pep-3147/).
 
 ## Standard Module
 
-Python wird mit einer relativ umfangreichen Bibliothek von Standardmodulen ausgeliefert, die der [Python Library Reference](https://docs.python.org/3/library/index.html), beschrieben sind. Einige Module sind in den Interpreter eingebaut. Diese ermöglichen den Zugriff auf Operationen, die nicht Teil des Kerns der Sprache aber dennoch eingebaut sind, entweder aus Gründen der Effizienz oder um den Zugriff auf Betriebssystem-Primitive wie Systemaufrufe zu ermöglichen.
+Python wird mit einer relativ umfangreichen Bibliothek von Standardmodulen ausgeliefert, die in
+der [Python Library Reference](https://docs.python.org/3/library/index.html) beschrieben sind. Einige Module sind in
+dem Interpreter eingebaut. Diese ermöglichen den Zugriff auf Operationen, die nicht Teil des Kerns der Sprache sind, 
+aber dennoch eingebaut sind, entweder aus Gründen der Effizienz oder um den Zugriff auf Betriebssystemprimitive wie
+Systemaufrufe zu ermöglichen.
 
-Die Menge solcher Module ist eine Konfigurationsoption, die auch von der zugrunde liegenden Plattform abhängt. Das Modul `winreg` ist beispielsweise nur auf Windows-Systemen verfügbar. Ein besonderes Modul verdient etwas Aufmerksamkeit: [sys](https://docs.python.org/3/library/sys.html#module-sys), das in jeden Python-Interpreter eingebaut ist. Die Variablen `sys.ps1` und `sys.ps2` definieren beispielsweise die Zeichenketten, die als primäre und sekundäre Prompts verwendet werden. Diese beiden Variablen sind nur allerdings definiert, wenn sich der Interpreter im interaktiven Modus befindet.
+Die Menge solcher Module ist eine Konfigurationsoption, die auch von der zugrunde liegenden Plattform abhängt. Das
+Modul `winreg` ist beispielsweise nur auf Windows-Systemen verfügbar. Ein Modul verdient besondere
+Aufmerksamkeit: [sys](https://docs.python.org/3/library/sys.html#module-sys), das in jeden Python-Interpreter eingebaut
+ist. Die Variablen `sys.ps1` und `sys.ps2` definieren beispielsweise die Zeichenketten, die als primäre und sekundäre
+Prompts verwendet werden. Diese beiden Variablen sind nur allerdings definiert, wenn sich der Interpreter im
+interaktiven Modus befindet.
 
 ```pycon
 >>> import sys
@@ -250,7 +348,10 @@ C> print('Yuck!')
 Yuck!
 C>
 ```
-Die Variable `sys.path` ist eine Liste von Strings, die den Suchpfad des Interpreters für Module bestimmt. Sie wird mit einem Standardpfad initialisiert, der aus der Umgebungsvariablen `PYTHONPATH` entnommen wird, oder aus einer eingebauten Vorgabe, wenn `PYTHONPATH` nicht gesetzt ist.  Man kann ihn mit Standard-Listenoperationen ändern:
+
+Die Variable `sys.path` ist eine Liste von Strings, die den Suchpfad des Interpreters für Module bestimmt. Sie wird mit
+einem Standardpfad initialisiert, der aus der Umgebungsvariablen `PYTHONPATH` entnommen wird, oder aus einer eingebauten
+Vorgabe, wenn `PYTHONPATH` nicht gesetzt ist. Man kann ihn mit Standard-Listenoperationen ändern:
 
 ```pycon
 >>> import sys
@@ -259,7 +360,8 @@ Die Variable `sys.path` ist eine Liste von Strings, die den Suchpfad des Interpr
 
 ## die dir() Funktion
 
-Die eingebaute Funktion [dir](https://docs.python.org/3/library/functions.html#dir) wird verwendet, um herauszufinden, welche Namen ein Modul definiert. Sie gibt eine sortierte Liste von Namen innerhalb des Moduls zurück:
+Die eingebaute Funktion [dir](https://docs.python.org/3/library/functions.html#dir) wird verwendet, um herauszufinden,
+welche Namen ein Modul definiert. Sie gibt eine sortierte Liste von Namen innerhalb des Moduls zurück:
 
 ```pycon
 >>> import fibo, sys
@@ -299,9 +401,12 @@ Ohne Argumente listet `dir` die Namen auf, die derzeit definiert sind:
 ['__builtins__', '__name__', 'a', 'fib', 'fibo', 'sys']
 ```
 
-Zu beachten ist, dass hier alle Arten von Namen aufgeführt sind: Variablen, Module, Funktionen usw. `dir(Modulname)` kann auch praktisch sein, wenn man ein Modul importiert hat, aber vergessen hat, welche Funktionen, Variablen etc darin eigentlich entahlten sind.
+Zu beachten ist, dass hier alle Arten von Namen aufgeführt sind: Variablen, Module, Funktionen usw. `dir(Modulname)`
+kann auch praktisch sein, wenn man ein Modul importiert hat, aber vergessen hat, welche Funktionen, Variablen etc darin
+eigentlich entahlten sind.
 
-In `dir` sind die Namen der eingebauten Funktionen und Variablen nicht aufgeführt. Wenn man eine Liste dieser Funktionen und Variablen wünscht, muss man das Standardmodul `builtins` importieren und dafür `dir()` aufrufen:
+In `dir` sind die Namen der eingebauten Funktionen und Variablen nicht aufgeführt. Wenn man eine Liste dieser Funktionen
+und Variablen wünscht, muss man das Standardmodul `builtins` importieren und dafür `dir()` aufrufen:
 
 ```pycon
 >>> import builtins
@@ -339,9 +444,20 @@ In `dir` sind die Namen der eingebauten Funktionen und Variablen nicht aufgefüh
 
 ## Pakete
 
-Pakete sind eine Möglichkeit, den Modul-Namensraum von Python durch die Verwendung von "gepunkteten Modulnamen" zu strukturieren. Zum Beispiel bezeichnet der Modulname `A.B` ein Submodul namens `B` in einem Paket namens `A`. Genauso wie die Verwendung von Modulen die Autoren verschiedener Module davor bewahrt, sich um die Namen der globalen Variablen des jeweils anderen kümmern zu müssen, erspart die Verwendung von gepunkteten Modulnamen den Autoren von Paketen mit mehreren Modulen wie NumPy oder Pillow, sich um die Namen der Module des jeweils anderen kümmern zu müssen.
+Pakete sind eine Möglichkeit, den Modul-Namensraum von Python durch die Verwendung von "gepunkteten Modulnamen" zu
+strukturieren. Zum Beispiel bezeichnet der Modulname `A.B` ein Submodul namens `B` in einem Paket namens `A`. Genauso
+wie die Verwendung von Modulen die Autoren verschiedener Module davor bewahrt, sich um die Namen der globalen Variablen
+des jeweils anderen kümmern zu müssen, erspart die Verwendung von gepunkteten Modulnamen den Autoren von Paketen mit
+mehreren Modulen wie NumPy oder Pillow, sich um die Namen der Module des jeweils anderen kümmern zu müssen.
 
-Angenommen, man will eine Sammlung von Modulen (ein "Paket") für die einheitliche Handhabung von Tondateien und Tondaten entwerfen. Es gibt viele verschiedene Tondateiformate (in der Regel an der Dateierweiterung zu erkennen, z. B. `.wav`, `.aiff`, `.mp3`), so dass man möglicherweise eine wachsende Sammlung von Modulen für die Konvertierung zwischen den verschiedenen Dateiformaten erstellen und pflegen muss. Außerdem gibt es viele verschiedene Operationen, die man mit den Klangdaten durchführen möchte (z. B. Abmischen, Hinzufügen von Echo, Anwenden einer Equalizer-Funktion, Erzeugen eines künstlichen Stereoeffekts usw.), so dass man zusätzlich eine nicht enden wollenden Strom von Modulen zur Durchführung dieser Operationen schreiben müsste. Hier ist eine mögliche Struktur für das Paket (ausgedrückt in Form eines hierarchischen Dateisystems):
+Angenommen, man will eine Sammlung von Modulen (ein "Paket") für die einheitliche Handhabung von Tondateien und Tondaten
+entwerfen. Es gibt viele verschiedene Tondateiformate (in der Regel an der Dateierweiterung zu erkennen, z.
+B. `.wav`, `.aiff`, `.mp3`), sodass man möglicherweise eine wachsende Sammlung von Modulen für die Konvertierung
+zwischen den verschiedenen Dateiformaten erstellen und pflegen muss. Außerdem gibt es viele verschiedene Operationen,
+die man mit den Klangdaten durchführen möchte (z. B. Abmischen, Hinzufügen von Echo, Anwenden einer Equalizer-Funktion,
+Erzeugen eines künstlichen Stereoeffekts usw.), sodass man zusätzlich eine nicht enden wollenden Anzahl von Modulen zur
+Durchführung dieser Operationen schreiben müsste. Hier ist eine mögliche Struktur für das Paket (ausgedrückt in Form
+eines hierarchischen Dateisystems):
 
 ```
    sound/                          Top-level package
@@ -369,9 +485,14 @@ Angenommen, man will eine Sammlung von Modulen (ein "Paket") für die einheitlic
                  ...
 ```
 
-Beim Importieren des Pakets durchsucht Python die Verzeichnisse in `sys.path` auf der Suche nach dem Unterverzeichnis des Pakets.
+Beim Importieren des Pakets durchsucht Python die Verzeichnisse in `sys.path` auf der Suche nach dem Unterverzeichnis
+des Pakets.
 
-Die `__init__.py`-Dateien werden benötigt, damit Python Verzeichnisse, die die Datei enthalten, als Pakete behandelt (es sei denn, es wird ein "Namensraumpaket" verwendet, eine relativ fortgeschrittene Funktion). Dies verhindert, dass Verzeichnisse mit einem gemeinsamen Namen, wie `string`, ungewollt gültige Module verstecken, die später auf dem Modulsuchpfad auftauchen. Im einfachsten Fall kann `__init__.py` einfach eine leere Datei sein, aber sie kann auch Initialisierungscode für das Paket ausführen oder die Variable `__all__` setzen, die später beschrieben wird.
+Die `__init__.py`-Dateien werden benötigt, damit Python Verzeichnisse, die die Datei enthalten, als Pakete behandelt (es
+sei denn, es wird ein "Namensraumpaket" verwendet, eine relativ fortgeschrittene Funktion). Dies verhindert, dass
+Verzeichnisse mit einem gemeinsamen Namen, wie `string`, ungewollt gültige Module verstecken, die später auf dem
+Modulsuchpfad auftauchen. Im einfachsten Fall kann `__init__.py` einfach eine leere Datei sein, aber sie kann auch
+Initialisierungscode für das Paket ausführen oder die Variable `__all__` setzen, die später beschrieben wird.
 
 Benutzer des Pakets können einzelne Module aus dem Paket importieren, wie zum Beispiel:
 
@@ -379,7 +500,7 @@ Benutzer des Pakets können einzelne Module aus dem Paket importieren, wie zum B
 import sound.effects.echo
 ```
 
-Dies lädt das Submodul `sound.effects.echo`.  Es muss mit seinem vollen Namen referenziert werden:
+Dies lädt das Submodul `sound.effects.echo`. Es muss mit seinem vollen Namen referenziert werden:
 
 ```python
 sound.effects.echo.echofilter(input, output, delay=0.7, atten=4)
@@ -391,7 +512,8 @@ Ein alternativer Weg zum Importieren von Submodulen ist:
 from sound.effects import echo
 ```
 
-Dies lädt auch das Submodul `echo`, und macht es ohne sein Paketpräfix verfügbar, so dass es wie folgt verwendet werden kann:
+Dies lädt auch das Submodul `echo` und macht es ohne sein Paketpräfix verfügbar, sodass es wie folgt verwendet werden
+kann:
 
 ```python
 echo.echofilter(input, output, delay=0.7, atten=4)
@@ -409,36 +531,60 @@ Dies lädt wiederum das Submodul `echo`, macht aber dessen Funktion `echofilter`
 echofilter(input, output, delay=0.7, atten=4)
 ```
 
-Zu beachten ist, dass bei der Verwendung von `from package import item` das Element entweder ein Untermodul (oder Unterpaket) des Pakets sein kann oder ein anderer im Paket definierter Name, wie eine Funktion, Klasse oder Variable. Die `import` Anweisung testet zuerst, ob das Element im Paket definiert ist. Wenn nicht, nimmt sie an, dass es ein Modul ist und versucht, es zu laden. Wenn es nicht gefunden wird, wird eine `ImportError` Ausnahme ausgelöst.
+Zu beachten ist, dass bei der Verwendung von `from package import item` das Element entweder ein Untermodul (oder
+Unterpaket) des Pakets sein kann oder ein anderer im Paket definierter Name, wie eine Funktion, Klasse oder Variable.
+Die `import` Anweisung testet zuerst, ob das Element im Paket definiert ist. Wenn nicht, nimmt sie an, dass es ein Modul
+ist und versucht es zu laden. Wenn es nicht gefunden wird, wird eine `ImportError` Ausnahme ausgelöst.
 
-Im Gegensatz dazu muss bei einer Syntax wie `import item.subitem.subsubitem` jedes Element außer dem letzten ein Paket sein. Das letzte Element kann ein Modul oder ein Paket sein, aber keine Klasse, Funktion oder Variable, die im vorherigen Element definiert ist.
+Im Gegensatz dazu muss bei einer Syntax wie `import item.subitem.subsubitem` jedes Element außer dem letzten ein Paket
+sein. Das letzte Element kann ein Modul oder ein Paket sein, aber keine Klasse, Funktion oder Variable, die im
+vorherigen Element definiert ist.
 
 ### Sternchen-Importe aus einem Paket
 
-Was passiert nun, wenn der Benutzer `from sound.effects import *` schreibt? Idealerweise würde man hoffen, dass Python irgendwie das Dateisystem durchsucht und herausfindet, welche Untermodule im Paket vorhanden sind, und sie alle importiert. Dies könnte sehr lange dauern und der Import von Untermodulen könnte unerwünschte Nebeneffekte haben, die nur auftreten sollten, wenn das Untermodul explizit importiert wird.
+Was passiert nun, wenn der Benutzer `from sound.effects import *` schreibt? Idealerweise würde man hoffen, dass Python
+irgendwie das Dateisystem durchsucht und herausfindet, welche Untermodule im Paket vorhanden sind und sie alle
+importiert. Dies könnte sehr lange dauern und der Import von Untermodulen könnte unerwünschte Nebeneffekte haben, die
+nur auftreten sollten, wenn das Untermodul explizit importiert wird.
 
-Die Lösung besteht darin, dass der Paketautor einen expliziten Index des Pakets bereitstellt. Die `import` Anweisung verwendet die folgende Konvention: Wenn der `__init__.py` Code eines Pakets eine Liste namens `__all__` definiert, wird diese als die Liste der Modulnamen angesehen, die importiert werden sollen, wenn `from Package import *` aufgerufen wird. Es ist Sache des Paketautors, diese Liste aktuell zu halten, wenn eine neue Version des Pakets veröffentlicht wird. Paketautoren können auch entscheiden, dies nicht zu unterstützen, wenn sie keinen Nutzen für den Import von Stenrchen-Import aus ihrem Paket sehen. Zum Beispiel könnte die Datei `sound/effects/__init__.py` den folgenden Code enthalten:
+Die Lösung besteht darin, dass der Paketautor einen expliziten Index des Pakets bereitstellt. Die `import` Anweisung
+verwendet die folgende Konvention: Wenn der `__init__.py` Code eines Pakets eine Liste namens `__all__` definiert, wird
+diese als die Liste der Modulnamen angesehen, die importiert werden sollen, wenn `from Package import *` aufgerufen
+wird. Es ist Sache des Paketautors, diese Liste aktuell zu halten, wenn eine neue Version des Pakets veröffentlicht
+wird. Paketautoren können auch entscheiden, dies nicht zu unterstützen, wenn sie keinen Nutzen für den Import von
+Sternchen-Importe aus ihrem Paket sehen. Zum Beispiel könnte die Datei `sound/effects/__init__.py` den folgenden Code
+enthalten:
 
 ```python
 __all__ = ["echo", "surround", "reverse"]
 ```
 
-Das würde bedeuten, dass `from sound.effects import *` die drei genannten Untermodule des `sound.effects` Pakets importieren würde.
+Das würde bedeuten, dass `from sound.effects import *` die drei genannten Untermodule des `sound.effects` Pakets
+importieren würde.
 
-Zu beachten ist, dass Untermodule durch lokal definierte Namen überschattet werden können. Wenn man zum Beispiel eine `reverse` Funktion in die Datei `sound/effects/__init__.py` hinzufügen, würde der Aufruf `from sound.effects import *` nur die beiden Submodule `echo` und `surround` importieren, aber *nicht* das `reverse` Submodul, da es von der lokal definierten `reverse` Funktion überschattet wird:
+Zu beachten ist, dass Untermodule durch lokal definierte Namen überschattet werden können. Wenn man zum Beispiel
+eine `reverse` Funktion in die Datei `sound/effects/__init__.py` hinzufügt, würde der
+Aufruf `from sound.effects import *` nur die beiden Submodule `echo` und `surround` importieren, aber *nicht*
+das `reverse` Submodul, da es von der lokal definierten `reverse` Funktion überschattet wird:
 
 ```python
 __all__ = [
-    "echo",      # referenziert die 'echo.py' Datei
+    "echo",  # referenziert die 'echo.py' Datei
     "surround",  # referenziert die 'surround.py' Datei
-    "reverse",   # ! referenziert jetzt hier die 'reverse' Funktion !
+    "reverse",  # ! referenziert jetzt hier die 'reverse' Funktion !
 ]
 
+
 def reverse(msg: str):  # <-- dieser Name überschattet das 'reverse.py' Submodul
-    return msg[::-1]    #     wenn 'from sound.effects import *' aufgerufen wird
+    return msg[::-1]  # wenn 'from sound.effects import *' aufgerufen wird
 ```
 
-Wenn ``__all__`` nicht definiert ist, importiert die Anweisung `from sound.effects import *` *nicht* alle Untermodule aus dem Paket `sound.effects` in den aktuellen Namensraum. Sie stellt nur sicher, dass das Paket `sound.effects` importiert wurde (und führt möglicherweise jeglichen Initialisierungscode in `__init__.py` aus) und importiert dann alle Namen, die im Paket definiert sind. Dies schließt alle Namen ein, die durch `__init__.py` definiert (und Untermodule explizit geladen) wurden. Es schließt auch alle Untermodule des Pakets ein, die explizit durch vorherige `import` Anweisungen geladen wurden. Betrachtet man den folgenden Code:
+Wenn ``__all__`` nicht definiert ist, importiert die Anweisung `from sound.effects import *` *nicht* alle Untermodule
+aus dem Paket `sound.effects` in den aktuellen Namensraum. Sie stellt nur sicher, dass das Paket `sound.effects`
+importiert wurde (und führt möglicherweise jeglichen Initialisierungscode in `__init__.py` aus) und importiert dann alle
+Namen, die im Paket definiert sind. Dies schließt alle Namen ein, die durch `__init__.py` definiert (und Untermodule
+explizit geladen) wurden. Es schließt auch alle Untermodule des Pakets ein, die explizit durch vorherige `import`
+Anweisungen geladen wurden. Betrachtet man den folgenden Code:
 
 ```python
 import sound.effects.echo
@@ -446,32 +592,50 @@ import sound.effects.surround
 from sound.effects import *
 ```
 
-In diesem Beispiel werden die Module `echo` und `surround` in den aktuellen Namespace importiert, weil sie im Paket `sound.effects` definiert sind, wenn die Anweisung `from...import` ausgeführt wird.  Dies funktioniert auch, wenn `__all__` definiert ist.
+In diesem Beispiel werden die Module `echo` und `surround` in den aktuellen Namespace importiert, weil sie im
+Paket `sound.effects` definiert sind, wenn die Anweisung `from...import` ausgeführt wird. Dies funktioniert auch,
+wenn `__all__` definiert ist.
 
-Obwohl bestimmte Module so konzipiert sind, dass sie nur Namen exportieren, die bestimmten Mustern folgen, wenn Sie `import *` verwenden, wird `import *` nach wie vor als schlechter Stil angesehen und sollte von daher im eigenen Code vermieden werden.
+Obwohl bestimmte Module so konzipiert sind, dass sie nur Namen exportieren, die bestimmten Mustern folgen, wenn
+Sie `import *` verwenden, wird `import *` nach wie vor als schlechter Stil angesehen und sollte von daher im eigenen
+Code vermieden werden.
 
-Aber es ist nicht falsch, `from package import specific_submodule` zu verwenden! Dies ist sogar die empfohlene Schreibweise, es sei denn, das importierende Modul muss Submodule mit demselben Namen aus verschiedenen Paketen verwenden.
+Aber es ist nicht falsch, `from package import specific_submodule` zu verwenden! Dies ist sogar die empfohlene
+Schreibweise, es sei denn, das importierende Modul muss Submodule mit demselben Namen aus verschiedenen Paketen
+verwenden.
 
 ### Intra-Paket Referenzen
 
-Wenn Pakete in Unterpakete strukturiert sind (wie das Paket `sound` im Beispiel oben), kann man absolute Importe verwenden, um auf Untermodule von Geschwisterpaketen zu verweisen. Wenn zum Beispiel das Modul `sound.filters.vocoder` das Modul `echo` aus dem Paket `sound.effects` verwenden muss, kann es `from sound.effects import echo` für den Import verwenden.
+Wenn Pakete in Unterpakete strukturiert sind (wie das Paket `sound` im Beispiel oben), kann man absolute Importe
+verwenden, um auf Untermodule von Geschwisterpaketen zu verweisen. Wenn zum Beispiel das Modul `sound.filters.vocoder`
+das Modul `echo` aus dem Paket `sound.effects` verwenden muss, kann es `from sound.effects import echo` für den Import
+verwenden.
 
-Man kann auch relative Importe schreiben, mit der Form der Import-Anweisung "from module import name". Diese Importe verwenden führende Punkte, um die aktuellen und übergeordneten Pakete anzuzeigen, die am relativen Import beteiligt sind.  Aus dem Modul `surround` heraus könnte man z.B. verwenden
+Man kann auch relative Importe schreiben, mit der Form der Import-Anweisung "from module import name". Diese Importe
+verwenden führende Punkte, um die aktuellen und übergeordneten Pakete anzuzeigen, die am relativen Import beteiligt
+sind. Aus dem Modul `surround` heraus könnte man z.B. verwenden
 
 ```python
 from . import echo
 from .. import formats
 from ..filters import equalizer
 ```
-Zu beachten ist, dass sich relative Importe auf den Namen des aktuellen Moduls beziehen.  Da der Name des Hauptmoduls immer `"__main__"` ist, müssen Module, die als Hauptmodul einer Python-Anwendung verwendet werden sollen, immer absolute Importe verwenden.
+
+Zu beachten ist, dass sich relative Importe auf den Namen des aktuellen Moduls beziehen. Da der Name des Hauptmoduls
+immer `"__main__"` ist, müssen Module, die als Hauptmodul einer Python-Anwendung verwendet werden sollen, immer absolute
+Importe verwenden.
 
 ### Pakete in mehreren Verzeichnissen
 
-Pakete unterstützen ein weiteres spezielles Attribut, `__path__`.  Dieses wird als Liste initialisiert, die den Namen des Verzeichnisses enthält, das die `__init__.py` des Pakets enthält, bevor der Code in dieser Datei ausgeführt wird.  Diese Variable kann geändert werden. Dies beeinflusst die zukünftige Suche nach Modulen und Unterpaketen, die in dem Paket enthalten sind.
+Pakete unterstützen ein weiteres spezielles Attribut, `__path__`. Dieses wird als Liste initialisiert, die den Namen des
+Verzeichnisses enthält, das die `__init__.py` des Pakets enthält, bevor der Code in dieser Datei ausgeführt wird. Diese
+Variable kann geändert werden. Dies beeinflusst die zukünftige Suche nach Modulen und Unterpaketen, die in dem Paket
+enthalten sind.
 
-Obwohl diese Funktion nicht oft benötigt wird, kann sie verwendet werden, um die Menge der in einem Paket gefundenen Module zu erweitern.
+Obwohl diese Funktion nicht oft benötigt wird, kann sie verwendet werden, um die Menge der in einem Paket gefundenen
+Module zu erweitern.
 
 ***
 
- * nächstes Kapitel: [Eingabe und Ausgabe](inputoutput.md)
- * vorheriges Kapitel: [Datenstrukturen und Datentypen](datastructures.md)
+* nächstes Kapitel: [Eingabe und Ausgabe](inputoutput.md)
+* vorheriges Kapitel: [Datenstrukturen und Datentypen](datastructures.md)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -17,7 +17,7 @@ def fib(n):
     a, b = 0, 1
     while a < n:
         print(a, end=' ')
-        a, b = b, a + b
+        a, b = b, a+b
     print()
 
 
@@ -28,7 +28,7 @@ def fib2(n):
     a, b = 0, 1
     while a < n:
         result.append(a)
-        a, b = b, a + b
+        a, b = b, a+b
     return result
 ```
 
@@ -152,7 +152,7 @@ import sys
 def square(number):
     '''Returns the square of a given number'''
 
-    return number ** 2
+    return number**2
 
 
 if len(sys.argv) > 1:
@@ -190,7 +190,7 @@ import sys
 def square(number):
     '''Returns the square of a given number'''
 
-    return number ** 2
+    return number**2
 
 
 if __name__ == "__main__":
@@ -438,14 +438,14 @@ Zu beachten ist, dass Untermodule durch lokal definierte Namen überschattet wer
 
 ```python
 __all__ = [
-    "echo",  # referenziert die 'echo.py' Datei
+    "echo",      # referenziert die 'echo.py' Datei
     "surround",  # referenziert die 'surround.py' Datei
-    "reverse",  # ! referenziert jetzt hier die 'reverse' Funktion !
+    "reverse",   # ! referenziert jetzt hier die 'reverse' Funktion !
 ]
 
 
 def reverse(msg: str):  # <-- dieser Name überschattet das 'reverse.py' Submodul
-    return msg[::-1]  # wenn 'from sound.effects import *' aufgerufen wird
+    return msg[::-1]    # wenn 'from sound.effects import *' aufgerufen wird
 ```
 
 Wenn ``__all__`` nicht definiert ist, importiert die Anweisung `from sound.effects import *` *nicht* alle Untermodule aus dem Paket `sound.effects` in den aktuellen Namensraum. Sie stellt nur sicher, dass das Paket `sound.effects` importiert wurde (und führt möglicherweise jeglichen Initialisierungscode in `__init__.py` aus) und importiert dann alle Namen, die im Paket definiert sind. Dies schließt alle Namen ein, die durch `__init__.py` definiert (und Untermodule explizit geladen) wurden. Es schließt auch alle Untermodule des Pakets ein, die explizit durch vorherige `import` Anweisungen geladen wurden. Betrachtet man den folgenden Code:


### PR DESCRIPTION
Typos, remove to many space and Line breaks inserted at 120 characters (in the file modules.md) for better readability in editors (PyCharm) The line breaks should not be visible in readthedocs, if this works I will submit this change for all other files later.