### PR TITLE
Aligning capitalization and footer navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Es wird empfohlen das Tutorial chronologisch durchzuarbeiten. Die Reihenfolge de
 
  1. [Startseite](docs/start.md): Startseite des Tutorials
  2. [Ein kleiner Appetitanreger](docs/appetite.md) für Python
- 3. [den Python-Interprter nutzen](docs/interpreter.md): kurze Einführung in die Nutzung des interaktiven Python-Interpreters
+ 3. [Den Python-Interprter nutzen](docs/interpreter.md): kurze Einführung in die Nutzung des interaktiven Python-Interpreters
  4. [eine lockere Einführung in Python](docs/introduction.md): erste Schritte mit Python, Python als Taschenrechner benutzen, Einführung in die Datentypen int, str und list, die ersten Schritte zum ersten Programm
  5. [weitere Werkzeuge zur Steuerung des Programmflusses](docs/controlflow.md): if-Bedingen, Schleifen mit for, die range-Funktion, break, continue und else für Schleifen, Definition von und Umgang mit Funktionen, Lambda Ausdrücke, Doc Strings und Funktionsannotation
  6. [Datenstrukturen und Datentypen](docs/datastructures.md): mehr Informationen zu Datentypen und -strukturen: Listen und deren Methoden, List Comprehensions, Wörterbücher (Dictionaries), Tupel, Sets, mehr zur if-Bedingung und while-Schleifen

--- a/README.md
+++ b/README.md
@@ -9,17 +9,17 @@ Ein Tutorial für Python für alle, die die Programmiersprache lernen möchten. 
 Es wird empfohlen das Tutorial chronologisch durchzuarbeiten. Die Reihenfolge der Kapitel ist wie folgt:
 
  1. [Startseite](docs/start.md): Startseite des Tutorials
- 2. [Ein kleiner Appetitanreger](docs/appetite.md) für Python
+ 2. [Ein kleiner Appetitanreger auf Python](docs/appetite.md)
  3. [Den Python-Interprter nutzen](docs/interpreter.md): kurze Einführung in die Nutzung des interaktiven Python-Interpreters
- 4. [eine lockere Einführung in Python](docs/introduction.md): erste Schritte mit Python, Python als Taschenrechner benutzen, Einführung in die Datentypen int, str und list, die ersten Schritte zum ersten Programm
- 5. [weitere Werkzeuge zur Steuerung des Programmflusses](docs/controlflow.md): if-Bedingen, Schleifen mit for, die range-Funktion, break, continue und else für Schleifen, Definition von und Umgang mit Funktionen, Lambda Ausdrücke, Doc Strings und Funktionsannotation
+ 4. [Eine lockere Einführung in Python](docs/introduction.md): erste Schritte mit Python, Python als Taschenrechner benutzen, Einführung in die Datentypen int, str und list, die ersten Schritte zum ersten Programm
+ 5. [Weitere Werkzeuge zur Steuerung des Programmflusses](docs/controlflow.md): if-Bedingungen, Schleifen mit for, die range-Funktion, break, continue und else für Schleifen, Definition von und Umgang mit Funktionen, Lambda Ausdrücke, Doc Strings und Funktionsannotation
  6. [Datenstrukturen und Datentypen](docs/datastructures.md): mehr Informationen zu Datentypen und -strukturen: Listen und deren Methoden, List Comprehensions, Wörterbücher (Dictionaries), Tupel, Sets, mehr zur if-Bedingung und while-Schleifen
  7. [Module](docs/modules.md): was sind Module in Python, wie erstellt man diese, wie importiert man diese, die `dir()` Funktion zur Anzeige von Informationen zu Modulen, Einführung in die Struktur von Paketen (für größere Programmierprojekte)
- 8. [Ein- und Ausgabe](docs/inputoutput.md): Ein- und Ausgabe mit print besser und flexibler formatieren, Lesen und Schreiben von Dateien, Daten strukturiert als JSON speichern
+ 8. [Eingabe und Ausgabe](docs/inputoutput.md): Ein- und Ausgabe mit print besser und flexibler formatieren, Lesen und Schreiben von Dateien, Daten strukturiert als JSON speichern
  9. [Fehler und Ausnahmen (Exceptions)](docs/errors.md): wie Python Fehler und Ausnahmen im Programmcode meldet, Umgang und Abfangen von Ausnahmen, eigene Ausnahmen definieren
  10. [Klassen](docs/classes.md): wie man Klassen in Python erstellt und nutzt
- 11. [eine (kurze) Tour durch die Standardbibliothek](docs/stdlib.md): kurze Vorstellung einiger gängiger und häufiger genutzter Module aus der Python Standardbibliothek
- 12. [virtuelle Umgebungen und Paketverwaltung mit pip](docs/venv.md): wie man virtuelle Umgebungen (Virtual Environments) erstellt und nutzt sowie Python Pakete mithilfe von pip installiert
+ 11. [Eine (kurze) Tour durch die Standardbibliothek](docs/stdlib.md): kurze Vorstellung einiger gängiger und häufiger genutzter Module aus der Python Standardbibliothek
+ 12. [Virtuelle Umgebungen und Paketverwaltung mit pip](docs/venv.md): wie man virtelle Umgebungen (Virtual Environments) erstellt und nutzt sowie Python Pakete mit Hilfe von pip installiert
  13. [Was kommt als Nächstes?](docs/whatnow.md): hilfreiche Links und weiterführende Webseiten
  14. [Tipps und Anmerkungen](docs/remarks.md): ein paar Tipps und Anmerkungen zu den ersten Projekten, GUI-Programmierung, nebenläufiger Programmierung und alternativen Python-Implementierung
- 15. [externe Module](docs/externallibs.md): ein kurzer Überblick über einige viel genutzte und populäre externe Python-Module
+ 15. [Externe Module](docs/externallibs.md): ein kurzer Überblick über einige viel genutzte und populäre externe Python-Module

--- a/docs/appetite.md
+++ b/docs/appetite.md
@@ -32,5 +32,6 @@ Im weiteren Verlauf des Tutorials werden verschiedene Funktionen der Sprache und
 
 ***
 
- * Nächste Seite: [Den Python-Interpreter nutzen](interpreter.md)
- * Vorherige Seite: [Startseite](start.md)
+ * Nächstes Kapitel: [Den Python-Interpreter nutzen](interpreter.md)
+ * Vorheriges Kapitel: [Startseite](start.md)
+ * Zurück zur [Startseite](index.md)

--- a/docs/appetite.md
+++ b/docs/appetite.md
@@ -32,5 +32,5 @@ Im weiteren Verlauf des Tutorials werden verschiedene Funktionen der Sprache und
 
 ***
 
- * nächste Seite: [den Python-Interpreter nutzen](interpreter.md)
- * vorherige Seite: [Startseite](start.md)
+ * Nächste Seite: [Den Python-Interpreter nutzen](interpreter.md)
+ * Vorherige Seite: [Startseite](start.md)

--- a/docs/classes.md
+++ b/docs/classes.md
@@ -8,7 +8,7 @@ In der C++-Terminologie sind Klassenmitglieder (einschließlich der Datenmitglie
 
 In Ermangelung einer allgemeingültigen Terminologie für Klassen werden hier gelegentlich Begriffe aus Smalltalk und C++ verwendet. Genauer wäre es, man würde die Begriffe von Modula-3 verwenden, da dessen objektorientierte Semantik näher an der von Python als an der von C++ ist - aber [Modula-3](https://en.wikipedia.org/wiki/Modula-3) gehört zu den - zumindest heutzutage - unbekannten und wenig verwendeten Programmiersprachen.
 
-## ein paar Worte zu Namen und Klassen
+## Ein paar Worte zu Namen und Klassen
 
 Objekte haben Individualität, und mehrere Namen (in mehreren Bereichen) können an dasselbe Objekt gebunden werden. Dies ist in anderen Sprachen als "Aliasing" bekannt. Dies wird in der Regel nicht auf den ersten Blick in Python erkannt und kann beim Umgang mit unveränderlichen Grundtypen (Zahlen, Strings, Tupel) auch ignoriert werden. Das Aliasing hat jedoch eine möglicherweise überraschende Auswirkung auf die Semantik von Python-Code, der veränderliche Objekte wie z.B. Listen, Wörterbücher etc. enthält. Dies wird in der Regel zum Vorteil des Programms genutzt, da sich Aliase in mancher Hinsicht wie Zeiger verhalten. Zum Beispiel ist die Übergabe eines Objekts billig (billig im Sinne von mit minimalem Aufwand verbunden), da nur ein Zeiger von der Implementierung übergeben wird. Und wenn eine Funktion ein als Argument übergebenes Objekt ändert, sieht der Aufrufer die Änderung - dies eliminiert die Notwendigkeit für zwei verschiedene Mechanismen der Argumentübergabe wie in Pascal.
 
@@ -232,7 +232,7 @@ Des Weiteren muss für in `__init__` definierte Variablen nicht zwingend ein Wer
 
 Wie man `Demo.number` dann einen Wert zuweist wird im folgenden Abschnitt erklärt.
 
-### Instanz Objekte
+### Instanzobjekte
 
 Was kann man nun mit Instanzobjekten tun? Die einzigen Operationen, die von Instanzobjekten verstanden werden, sind Attributreferenzen. Es gibt zwei Arten von gültigen Attributnamen: Datenattribute und Methoden.
 
@@ -251,7 +251,7 @@ Die andere Art der Instanzattribut-Referenz ist eine *Methode*. Eine Methode ist
 
 Gültige Methodennamen eines Instanzobjekts hängen von seiner Klasse ab. Per Definition definieren alle Attribute einer Klasse, die Funktionsobjekte sind, entsprechende Methoden ihrer Instanzen. In dem Beispiel weiter oben mit der `SomethingSimple` Klasse ist also `x.f` eine gültige Methodenreferenz, da `SomethingSimple.f` eine Funktion ist, aber `x.i` ist keine, da `SomethingSimple.i` keine ist. Aber `x.f` ist nicht dasselbe wie `SomethingSimple.f` - es ist ein *Methodenobjekt*, kein Funktionsobjekt.
 
-### Methoden Objekte
+### Methodenobjekte
 
 Normalerweise wird eine Methode direkt nach ihrer Bindung aufgerufen:
 
@@ -339,7 +339,7 @@ Bei einem korrekten Entwurf der Klasse sollte stattdessen eine Instanzvariable v
 ['play dead']
 ```
 
-## zusätzliche Hinweise
+## Zusätzliche Hinweise
 
 Wenn derselbe Attributname sowohl in einer Instanz als auch in einer Klasse vorkommt, dann hat das Instanzattribut Vorrang vor dem der Klasse:
 
@@ -400,7 +400,7 @@ Methoden können auf globale Namen in der gleichen Weise verweisen wie normale F
 
 Jeder Wert ist ein Objekt und hat daher eine *Klasse*, auch *Typ* (auf Englisch: *type*) genannt. Sie wird als `Objekt.__Klasse__` gespeichert.
 
-### @property für Methoden
+### Methoden mit @property
 Es gibt Anwendungsfälle, wo man in Klassen eine Methode definiert, aber in den Instanzen der Klasse darauf lieber wie auf ein Datenattribut zugreifen würde. Beispiel:
 
 ```pycon
@@ -491,7 +491,7 @@ Python hat zwei eingebaute Funktionen, die mit Vererbung arbeiten:
  * `isinstance` wird verwendet, um den Typ einer Instanz zu prüfen: `isinstance(obj, int)` ist nur `True`, wenn `obj.__class__` `int` oder eine von `int` abgeleitete Klasse ist.
  * `issubclass` wird verwendet, um die Klassenvererbung zu prüfen: `issubclass(bool, int)` ist nur `True`, wenn `bool` eine Unterklasse von `int` ist. Aber `issubclass(float, int)` ist `False`, da `float` keine Unterklasse von `int` ist.
 
-### mehrfache Vererbung
+### Mehrfache Vererbung
 
 Python unterstützt auch Mehrfachvererbung. Eine Klassendefinition mit mehreren Basisklassen sieht wie folgt aus:
 
@@ -510,7 +510,7 @@ Tatsächlich ist es etwas komplexer als das. Die Reihenfolge der Methodenauflös
 
 Dynamische Ordnung ist notwendig, weil alle Fälle von Mehrfachvererbung eine oder mehrere rautenförmige Beziehungen aufweisen, bei denen auf mindestens eine der Elternklassen über mehrere Pfade von der untersten Klasse aus zugegriffen werden kann. Zum Beispiel erben alle Klassen von `object`, sodass jeder Fall von Mehrfachvererbung mehr als einen Pfad bietet, um `object` zu erreichen. Um zu verhindern, dass auf die Basisklassen mehr als einmal zugegriffen wird, linearisiert der dynamische Algorithmus die Suchreihenfolge so, dass die in jeder Klasse angegebene Reihenfolge von links nach rechts erhalten bleibt, jede übergeordnete Klasse nur einmal aufgerufen wird und der Algorithmus monoton ist (d. h., dass eine Klasse untergeordnet werden kann, ohne die Rangfolge ihrer übergeordneten Klassen zu verändern). Zusammengenommen ermöglichen diese Eigenschaften die Entwicklung zuverlässiger und erweiterbarer Klassen mit Mehrfachvererbung.
 
-## private Variablen
+## Private Variablen
 
 "Private" Instanzvariablen, auf die nur innerhalb eines Objekts zugegriffen werden kann, gibt es in Python nicht. Grundsätzlich kann man auf alles von außerhalb zugreifen. Es gibt jedoch eine Konvention, die von den meisten Python-Programmierern befolgt wird: Ein Name, dem ein Unterstrich vorangestellt ist (z.B. `_spam`), sollte als nicht-öffentlicher Teil einer Klasse / der API behandelt werden (egal ob es sich um eine Funktion, eine Methode oder ein Datenelement handelt). Es sollte als ein Implementierungsdetail betrachtet werden und könnte ohne Vorankündigung geändert werden oder auch verschwinden.
 
@@ -545,7 +545,7 @@ Zu beachten ist, dass die Mangling-Regeln hauptsächlich dazu gedacht sind, unge
 
 Außerdem ist zu beachten, dass Code, der an `exec()` oder `eval()` übergeben wird, den Klassennamen der aufrufenden Klasse nicht als die aktuelle Klasse betrachtet. Dies ist vergleichbar mit der Wirkung der `global` Anweisung, deren Auswirkung ebenfalls auf Code beschränkt ist, der zusammen zu Bytecode kompiliert wird. Die gleiche Einschränkung gilt für `getattr()`, `setattr()` und `delattr()`, sowie bei der direkten Referenzierung von `__dict__`.
 
-## andere Kleinigkeiten
+## Andere Kleinigkeiten
 
 Manchmal ist es nützlich, einen Datentyp ähnlich dem Pascal-"record" oder C-"struct" zu haben, der einige benannte Datenelemente zusammenfasst. Der idiomatische Ansatz ist die Verwendung des Moduls [dataclasses](https://docs.python.org/3/library/dataclasses.html) (welche mit Python 3.7 eingeführt wurden) für diesen Zweck:
 
@@ -681,5 +681,5 @@ Beispiele:
 
 ***
 
- * nächstes Kapitel: [kurze Tour durch die Standardbibliothek](stdlib.md)
- * vorheriges Kapitel: [Fehler und Ausnahmen](errors.md)
+ * Nächstes Kapitel: [Kurze Tour durch die Standardbibliothek](stdlib.md)
+ * Vorheriges Kapitel: [Fehler und Ausnahmen](errors.md)

--- a/docs/classes.md
+++ b/docs/classes.md
@@ -681,5 +681,6 @@ Beispiele:
 
 ***
 
- * Nächstes Kapitel: [Kurze Tour durch die Standardbibliothek](stdlib.md)
- * Vorheriges Kapitel: [Fehler und Ausnahmen](errors.md)
+ * Nächstes Kapitel: [Eine (kurze) Tour durch die Standardbibliothek](stdlib.md)
+ * Vorheriges Kapitel: [Fehler und Ausnahmen (Exceptions)](errors.md)
+ * Zurück zur [Startseite](index.md)

--- a/docs/controlflow.md
+++ b/docs/controlflow.md
@@ -917,5 +917,7 @@ Für Python ist die [PEP8](https://peps.python.org/pep-0008/) der in der Python-
 
 ***
 
- * Nächstes Kapitel: [Datentypen und -strukturen](datastructures.md)
+ * Nächstes Kapitel: [Datenstrukturen und Datentypen](datastructures.md)
  * Vorheriges Kapitel: [Eine lockere Einführung in Python](introduction.md)
+ * Zurück zur [Startseite](index.md)
+ 

--- a/docs/controlflow.md
+++ b/docs/controlflow.md
@@ -1,8 +1,8 @@
-# weitere Werkzeuge zur Steuerung des Programmflusses
+# Weitere Werkzeuge zur Steuerung des Programmflusses
 
 Neben der im vorherigen Kapitel vorgestellten `while`-Anweisung gibt es Python noch einige weitere Anweisungen zur Steuerung des Programmflusses, die hier in diesem Kapitel erläutert werden.
 
-## if Bedingung
+## If-Bedingung
 
 Die vielleicht bekannteste und oft genutzte Anweisung ist die [if](https://docs.python.org/3/reference/compound_stmts.html#if) Bedingung. Beispiel:
 
@@ -28,7 +28,7 @@ Der Ausdruck hinter `if` und `elif` muss immer einen Wahrheitswert ergeben, also
 
 Wenn man denselben Wert mit mehreren Konstanten vergleichen oder nach bestimmten Typen oder Attributen suchen will, kann auch die Anweisung `match` nützlich sein, welche weiter unten noch erläutert wird.
 
-## for-Anweisung - Schleifen mit for
+## For-Anweisung - Schleifen mit for
 
 Die [for](https://docs.python.org/3/reference/compound_stmts.html#for) Anweisung von Python unterscheidet sich ein wenig von dem, was man vielleicht von anderen Programmiersprachen wie C oder Pascal gewohnt ist. Anstatt immer über eine arithmetische Folge von Zahlen zu iterieren (wie in Pascal) oder dem Benutzer die Möglichkeit zu geben, sowohl den Iterationsschritt als auch die Haltebedingung zu definieren (wie in C), iteriert Pythons `for` Anweisung über die Elemente einer beliebigen Sammlung (wie eine Liste oder eine Zeichenkette) in der Reihenfolge, in der sie in der Sammlung vorkommen. Zum Beispiel:
 
@@ -84,7 +84,7 @@ Das Iterieren über eine Sammlung, im Englischen auch als "iterable" bezeichnet,
 7
 ```
 
-## range-Funktion
+## Range-Funktion
 
 Wenn über eine Zahlenfolge iteriert werden muss, ist die eingebaute Funktion [range](https://docs.python.org/3/library/stdtypes.html#range) sehr nützlich. Sie erzeugt arithmetische Progressionen:
 
@@ -155,7 +155,7 @@ Ein solches Objekt ist "iterable", auf Deutsch: iterierbar, d.h. es eignet sich 
 
 Später werden noch mehr Funktionen zu sehen sein, die Iterables zurückgeben und Iterables als Argumente annehmen. Im Kapitel über Datenstrukturen wird z.B. ausführlicher über Listen gesprochen.
 
-## break und continue Anweisungen, else Klauseln in Schleifen
+## Break und continue Anweisungen, else Klauseln in Schleifen
 
 Die Anweisung [break](https://docs.python.org/3/reference/simple_stmts.html#break) bricht aus der innersten umschließenden `for` oder `while` Schleife aus.
 
@@ -210,7 +210,7 @@ Found an even number 8
 Found an odd number 9
 ```
 
-## pass Anweisung
+## Pass-Anweisung
 
 Die Anweisung [pass](https://docs.python.org/3/reference/simple_stmts.html#pass) bewirkt: nichts. 
 Sie kann verwendet werden, wenn eine Anweisung syntaktisch erforderlich ist, das Programm aber keine Aktion verlangt. Zum Beispiel:
@@ -237,7 +237,7 @@ Ein anderer Fall, an dem `pass` verwendet werden kann, ist als Platzhalter für 
 ...
 ```
 
-## match Anweisung
+## Match-Anweisung
 
 Eine [match](https://docs.python.org/3/reference/compound_stmts.html#match) Anweisung nimmt einen Ausdruck und vergleicht dessen Wert mit aufeinanderfolgenden Mustern, die als ein oder mehrere `case` Blöcke angegeben sind. Oberflächlich betrachtet ähnelt dies einer switch-Anweisung in C, Java oder JavaScript (und vielen anderen Sprachen), aber es ähnelt eher dem Mustervergleich in Sprachen wie Rust oder Haskell. Nur das erste Muster, das passt, wird ausgeführt, und es können auch Komponenten (Sequenzelemente oder Objektattribute) aus dem Wert in Variablen extrahiert werden.
 
@@ -491,7 +491,7 @@ SyntaxError: invalid syntax
 SyntaxError: invalid syntax
 ```
 
-## mehr zur Definition von Funktionen
+## Mehr zur Definition von Funktionen
 
 Es ist auch möglich, Funktionen mit einer variablen Anzahl von Argumenten zu definieren. Es gibt drei Formen, die miteinander kombiniert werden können.
 
@@ -646,7 +646,7 @@ sketch : Cheese Shop Sketch
 
 Zu beachten ist, dass die Reihenfolge, in der die Schlüsselwortargumente ausgegeben werden, garantiert der Reihenfolge entspricht, in der sie im Funktionsaufruf angegeben wurden.
 
-### spezielle Parameter
+### Spezielle Parameter
 
 Standardmäßig können Argumente an eine Python-Funktion entweder nach Position oder explizit nach Schlüsselwort übergeben werden. Aus Gründen der Lesbarkeit und der Leistung ist es sinnvoll, die Art und Weise, wie Argumente übergeben werden können, einzuschränken, sodass ein Entwickler nur einen Blick auf die Funktionsdefinition werfen muss, um festzustellen, ob Elemente per Position, per Position oder Schlüsselwort oder per Schlüsselwort übergeben werden.
 
@@ -671,7 +671,7 @@ Bei näherer Betrachtung ist es möglich, bestimmte Parameter als *positional-on
 
 Parameter, die dem `/` folgen, können *Positions- oder Schlüsselwort* oder *Nur-Schlüsselwort* sein.
 
-#### nur Schlüsselwortargumente
+#### Nur Schlüsselwortargumente
 
 Um Parameter als *keyword-only* zu kennzeichnen, was bedeutet, dass die Parameter per Schlüsselwortargument übergeben werden müssen, setzt man ein `*` in die Argumentenliste direkt vor den ersten *keyword-only* Parameter.
 
@@ -785,7 +785,7 @@ Als Richtlinie:
  * Man verwendet nur Schlüsselwörter, wenn die Namen eine Bedeutung haben und die Funktionsdefinition durch die explizite Angabe von Namen verständlicher ist oder man verhindern will, dass sich Benutzer auf die Position des übergebenen Arguments verlassen.
  * Für eine API sollte man nur Positionsangaben verwenden, um zu verhindern, dass die API kpautt ist, wenn der Name des Parameters in der Zukunft geändert werden sollte.
 
-### beliebige Argumentlisten
+### Beliebige Argumentlisten
 
 Die am seltensten verwendete Option ist schließlich die Angabe, dass eine Funktion mit einer beliebigen Anzahl von Argumenten aufgerufen werden kann. Diese Argumente werden in ein Tupel verpackt. Vor der variablen Anzahl von Argumenten können null oder mehr normale Argumente auftreten.
 
@@ -855,7 +855,7 @@ Im obigen Beispiel wird ein Lambda-Ausdruck verwendet, um eine Funktion zurückz
 [(4, 'four'), (1, 'one'), (3, 'three'), (2, 'two')]
 ```
 
-### docstrings
+### Docstrings
 
 Im Folgenden werden einige Konventionen für den Inhalt und die Formatierung von docstrings (=Dokumentationsstrings) erläutert.
 
@@ -917,5 +917,5 @@ Für Python ist die [PEP8](https://peps.python.org/pep-0008/) der in der Python-
 
 ***
 
- * nächstes Kapitel: [Datentypen und -strukturen](datastructures.md)
- * vorheriges Kapitel: [eine lockere Einführung in Python](introduction.md)
+ * Nächstes Kapitel: [Datentypen und -strukturen](datastructures.md)
+ * Vorheriges Kapitel: [Eine lockere Einführung in Python](introduction.md)

--- a/docs/datastructures.md
+++ b/docs/datastructures.md
@@ -2,7 +2,7 @@
 
 In diesem Kapitel werden einige Dinge, die bereits in vorherigen Kapiteln beschrieben wurden, ausführlicher erklärt. Und es kommen auch einige neue Datenstrukturen und ergänzende Informationen hinzu.
 
-## mehr zu Listen
+## Mehr zu Listen
 
 Der Datentyp Liste hat einige weitere Methoden. Im Folgenden alle Methoden von Listenobjekten:
 
@@ -183,7 +183,7 @@ List Comprehensions können komplexe Ausdrücke und verschachtelte Funktionen en
 
 List Comprehensions gelten im Allgemeinen als "pythonisch" und werden entsprechend häufig verwendet bzw. es gilt allgemein als empfehlenswert, List Comprehensions an passenden Stellen im Code zu verwenden.
 
-### verschachtelte List Comprehensions
+### Verschachtelte List Comprehensions
 
 Der Anfangsausdruck einer List Comprehension kann ein beliebiger Ausdruck sein, einschließlich einer anderen List Comprehension. Im folgenden Beispiel wird eine 3x4-Matrix, die als eine Liste von 3 Listen der Länge 4 implementiert ist, generiert:
 
@@ -234,7 +234,7 @@ In der realen Programmierwelt sollte man integrierte Funktionen komplexen Ablauf
 [(1, 5, 9), (2, 6, 10), (3, 7, 11), (4, 8, 12)]
 ```
 
-## die del Anweisung
+## Die del-Anweisung
 
 Es gibt eine Möglichkeit, ein Element aus einer Liste zu entfernen. Dazu dient die [del](https://docs.python.org/3/tutorial/datastructures.html) Anweisung in Kombination mit der Angabe des Indexes des Elements, das man entfernen möchte. `del` steht für `delete`, auf Deutsch: entfernen, löschen. Dies unterscheidet sich von der Methode `list.pop`, die einen Wert zurückgibt. Die Anweisung `del` kann auch verwendet werden, um Slices aus einer Liste zu entfernen oder die gesamte Liste zu löschen (was zuvor durch Zuweisung einer leeren Liste an den Slice gemacht wurde). Zum Beispiel:
 
@@ -421,7 +421,7 @@ Wenn die Schlüssel einfache Zeichenketten sind, ist es manchmal einfacher, Paar
 {'sape': 4139, 'guido': 4127, 'jack': 4098}
 ```
 
-### weitere Methoden von Wörterbüchern
+### Weitere Methoden von Wörterbüchern
 
 Iteriert man über ein Wörterbuch erhält man die Schlüssel als Rückgabewert. Um Schlüssel und Wert zu erhalten nutzt man die `dict.items()` Methode:
 
@@ -458,7 +458,7 @@ Gibt man bei `dict.get()` keinen Defaultwert an erhält man stattdessen `None` a
 
 Wörterbücher kennen noch eine ganze Reihe weiterer Optionen, welche [in der Dokumentation](https://docs.python.org/3/library/stdtypes.html#mapping-types-dict) nachgelesen werden können.
 
-## mehr zur Iteration über Datenstrukturen
+## Mehr zur Iteration über Datenstrukturen
 
 Das Iterieren über Schlüssel-Wert Paare eines Wörterbuchs wurde bereits im vorherigen Abschnitt gezeigt.
 
@@ -541,7 +541,7 @@ Manchmal ist es verlockend, eine Liste zu ändern, während man sie in einer Sch
 [56.2, 51.7, 55.3, 52.5, 47.8]
 ```
 
-## mehr über Bedingungen für if und while
+## Mehr über Bedingungen für if und while
 
 Die in `while` und `if` Anweisungen verwendeten Bedingungen können beliebige Operatoren enthalten, nicht nur einfache Vergleiche.
 
@@ -599,5 +599,5 @@ Zu beachten ist, dass der Vergleich von Objekten unterschiedlichen Typs mit `<` 
 
 ***
 
- * nächstes Kapitel: [Module](modules.md)
- * vorheriges Kapitel: [weitere Werkzeuge zur Steuerung des Programmflusses](controlflow.md)
+ * Nächstes Kapitel: [Module](modules.md)
+ * Vorheriges Kapitel: [Weitere Werkzeuge zur Steuerung des Programmflusses](controlflow.md)

--- a/docs/datastructures.md
+++ b/docs/datastructures.md
@@ -601,3 +601,5 @@ Zu beachten ist, dass der Vergleich von Objekten unterschiedlichen Typs mit `<` 
 
  * Nächstes Kapitel: [Module](modules.md)
  * Vorheriges Kapitel: [Weitere Werkzeuge zur Steuerung des Programmflusses](controlflow.md)
+ * Zurück zur [Startseite](index.md)
+ 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -267,7 +267,7 @@ RuntimeError
 
 Mehr Information über Verkettungsmechanismen findet man in der Python-Dokumentation unter [Built-in Exceptions](https://docs.python.org/3/library/exceptions.html#bltin-exceptions)
 
-## benutzerdefinierte Ausnahmen
+## Benutzerdefinierte Ausnahmen
 
 Programme können ihre eigenen Ausnahmen definieren, indem sie eine neue Ausnahmeklasse erstellen (mehr zu Klassen ist im entsprechenden Kapitel dieses Tutorial zu finden). Ausnahmen sollten normalerweise von der Klasse `Exception` abgeleitet werden, entweder direkt oder indirekt.
 
@@ -345,7 +345,7 @@ Wie man sehen kann, wird die `finally` Klausel auf jeden Fall ausgeführt. Der `
 
 In realen Anwendungen ist die `finally` Klausel nützlich, um externe Ressourcen (wie Dateien oder Netzwerkverbindungen) freizugeben, unabhängig davon, ob die Verwendung der Ressource erfolgreich war.
 
-## vordefinierte Ausräumaktionen
+## Vordefinierte Aufräumaktionen
 
 Einige Objekte definieren standardmäßige Aufräumaktionen, die durchgeführt werden, wenn das Objekt nicht mehr benötigt wird, unabhängig davon, ob die Operation, die das Objekt verwendet, erfolgreich war oder nicht. Im folgenden Beispiel wird versucht, eine Datei zu öffnen und ihren Inhalt auf den Bildschirm auszugeben:
 
@@ -511,5 +511,5 @@ Wenn man zum Beispiel Ausnahmen in einer Ausnahmegruppe sammelt, möchten man vi
 
 ***
 
- * nächstes Kapitel: [Klassen](classes.md)
- * vorheriges Kapitel: [Eingabe und Ausgabe](inputoutput.md)
+ * Nächstes Kapitel: [Klassen](classes.md)
+ * Vorheriges Kapitel: [Eingabe und Ausgabe](inputoutput.md)

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -513,3 +513,4 @@ Wenn man zum Beispiel Ausnahmen in einer Ausnahmegruppe sammelt, möchten man vi
 
  * Nächstes Kapitel: [Klassen](classes.md)
  * Vorheriges Kapitel: [Eingabe und Ausgabe](inputoutput.md)
+ * Zurück zur [Startseite](index.md)

--- a/docs/externallibs.md
+++ b/docs/externallibs.md
@@ -1,4 +1,4 @@
-# externe Python Module
+# Externe Python Module
 
 Es gibt zehntausende externe Python-Module, die man für eigene Programmierprojekte nutzen kann. Die primäre Anlaufstelle ist der [Python Package Index](https://pypi.org/) (kurz: PyPI, aber auch als "Cheese Shop" bekannt). Es gibt Python-Module für alle möglichen Anwendungen.
 
@@ -60,7 +60,7 @@ SQLAlchemy gibt es schon sehr lange, es ist sehr populär und entsprechend viel 
 
 *Randnotiz*: SQLAlchemy ist zusammen mit dem Django ORM sicherlich das (mit Abstand) meistgenutzte ORM für Python. Da das Django ORM voll in Django integriert ist (und außerhalb von Django nicht wirklich nutzbar ist), wird das Django ORM beim Erstellen von Webanwendungen mit Django genutzt und für alles andere bietet sich SQLAlchemy an.
 
-## weitere Tools
+## Weitere Tools
 Wie schon Eingangs erwähnt gibt es noch unzählig mehr Python-Module. Zwei weitere, die relativ oft genutzt werden und nützlich sind, sollen hier noch Erwähnung finden.
 
 Will man eine webbasierte / HTTP-basierte API abfragen, dann ist DAS Modul dafür [Requests](https://requests.readthedocs.io/en/latest/). Requests bietet eine sehr komfortable und nutzerfreundliche API zum Erstellen von HTTP-Requests sowie zum Auswerten der vom Server erhaltenen Antwort.
@@ -72,6 +72,6 @@ Will man eine webbasierte / HTTP-basierte API abfragen, dann ist DAS Modul dafü
  * vorherige Seite: [Tipps und Anmerkungen](remarks.md)
 
 Weitere Links:
- * [eine (kurze) Tour durch die Standardbibliothek](stdlib.md) - Überblick über einige in der Standardbibliothek enthaltenen Module
+ * [Eine (kurze) Tour durch die Standardbibliothek](stdlib.md) - Überblick über einige in der Standardbibliothek enthaltenen Module
  * [Startseite](index.md) - Startseite des Tutorials
 

--- a/docs/externallibs.md
+++ b/docs/externallibs.md
@@ -69,9 +69,5 @@ Will man eine webbasierte / HTTP-basierte API abfragen, dann ist DAS Modul dafü
 
 ***
 
- * vorherige Seite: [Tipps und Anmerkungen](remarks.md)
-
-Weitere Links:
- * [Eine (kurze) Tour durch die Standardbibliothek](stdlib.md) - Überblick über einige in der Standardbibliothek enthaltenen Module
- * [Startseite](index.md) - Startseite des Tutorials
-
+ * Vorheriges Kapitel: [Tipps und Anmerkungen](remarks.md)
+ * Zurück zur [Startseite](index.md) 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,19 +4,19 @@ Es wird empfohlen das Tutorial chronologisch durchzuarbeiten. Die Reihenfolge de
 
  1. [Startseite](start.md): Startseite des Tutorials
  2. [Ein kleiner Appetitanreger](appetite.md) für Python
- 3. [den Python-Interprter nutzen](interpreter.md): kurze Einführung in die Nutzung des interaktiven Python-Interpreters
- 4. [eine lockere Einführung in Python](introduction.md): erste Schritte mit Python, Python als Taschenrechner benutzen, Einführung in die Datentypen int, str und list, die ersten Schritte zum ersten Programm
- 5. [weitere Werkzeuge zur Steuerung des Programmflusses](controlflow.md): if-Bedingen, Schleifen mit for, die range-Funktion, break, continue und else für Schleifen, Definition von und Umgang mit Funktionen, Lambda Ausdrücke, Doc Strings und Funktionsannotation
+ 3. [Den Python-Interprter nutzen](interpreter.md): kurze Einführung in die Nutzung des interaktiven Python-Interpreters
+ 4. [Eine lockere Einführung in Python](introduction.md): erste Schritte mit Python, Python als Taschenrechner benutzen, Einführung in die Datentypen int, str und list, die ersten Schritte zum ersten Programm
+ 5. [Weitere Werkzeuge zur Steuerung des Programmflusses](controlflow.md): if-Bedingen, Schleifen mit for, die range-Funktion, break, continue und else für Schleifen, Definition von und Umgang mit Funktionen, Lambda Ausdrücke, Doc Strings und Funktionsannotation
  6. [Datenstrukturen und Datentypen](datastructures.md): mehr Informationen zu Datentypen und -strukturen: Listen und deren Methoden, List Comprehensions, Wörterbücher (Dictionaries), Tupel, Sets, mehr zur if-Bedingung und while-Schleifen
  7. [Module](modules.md): was sind Module in Python, wie erstellt man diese, wie importiert man diese, die `dir()` Funktion zur Anzeige von Informationen zu Modulen, Einführung in die Struktur von Paketen (für größere Programmierprojekte)
  8. [Ein- und Ausgabe](inputoutput.md): Ein- und Ausgabe mit print besser und flexibler formatieren, Lesen und Schreiben von Dateien, Daten strukturiert als JSON speichern
  9. [Fehler und Ausnahmen (Exceptions)](errors.md): wie Python Fehler und Ausnahmen im Programmcode meldet, Umgang und Abfangen von Ausnahmen, eigene Ausnahmen definieren
  10. [Klassen](classes.md): wie man Klassen in Python erstellt und nutzt
- 11. [eine (kurze) Tour durch die Standardbibliothek](stdlib.md): kurze Vorstellung einiger gängiger und häufiger genutzter Module aus der Python Standardbibliothek
- 12. [virtuelle Umgebungen und Paketverwaltung mit pip](venv.md): wie man virtellen Umgebungen (Virtual Environments) erstellt und nutzt sowie Python Pakete mit Hilfe von pip installiert
- 13. [Was kommt als nächstes?](whatnow.md): hilfreiche Links und weiterführende Webseiten
+ 11. [Eine (kurze) Tour durch die Standardbibliothek](stdlib.md): kurze Vorstellung einiger gängiger und häufiger genutzter Module aus der Python Standardbibliothek
+ 12. [Virtuelle Umgebungen und Paketverwaltung mit pip](venv.md): wie man virtellen Umgebungen (Virtual Environments) erstellt und nutzt sowie Python Pakete mit Hilfe von pip installiert
+ 13. [Was kommt als Nächstes?](whatnow.md): hilfreiche Links und weiterführende Webseiten
  14. [Tipps und Anmerkungen](remarks.md): ein paar Tipps und Anmerkungen zu den ersten Projekten, GUI-Programmierung, nebenläufiger Programmierung und alternativen Python-Implementierung
- 15. [externe Module](externallibs.md): ein kurzer Überblick über einige viel genutzte und populäre externe Python-Module
+ 15. [Externe Module](externallibs.md): ein kurzer Überblick über einige viel genutzte und populäre externe Python-Module
  
 ## Weitere Informationen zu PyTuDe
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,13 +3,13 @@
 Es wird empfohlen das Tutorial chronologisch durchzuarbeiten. Die Reihenfolge der Kapitel ist wie folgt:
 
  1. [Startseite](start.md): Startseite des Tutorials
- 2. [Ein kleiner Appetitanreger](appetite.md) für Python
+ 2. [Ein kleiner Appetitanreger auf Python](appetite.md)
  3. [Den Python-Interprter nutzen](interpreter.md): kurze Einführung in die Nutzung des interaktiven Python-Interpreters
  4. [Eine lockere Einführung in Python](introduction.md): erste Schritte mit Python, Python als Taschenrechner benutzen, Einführung in die Datentypen int, str und list, die ersten Schritte zum ersten Programm
- 5. [Weitere Werkzeuge zur Steuerung des Programmflusses](controlflow.md): if-Bedingen, Schleifen mit for, die range-Funktion, break, continue und else für Schleifen, Definition von und Umgang mit Funktionen, Lambda Ausdrücke, Doc Strings und Funktionsannotation
+ 5. [Weitere Werkzeuge zur Steuerung des Programmflusses](controlflow.md): if-Bedingungen, Schleifen mit for, die range-Funktion, break, continue und else für Schleifen, Definition von und Umgang mit Funktionen, Lambda Ausdrücke, Doc Strings und Funktionsannotation
  6. [Datenstrukturen und Datentypen](datastructures.md): mehr Informationen zu Datentypen und -strukturen: Listen und deren Methoden, List Comprehensions, Wörterbücher (Dictionaries), Tupel, Sets, mehr zur if-Bedingung und while-Schleifen
  7. [Module](modules.md): was sind Module in Python, wie erstellt man diese, wie importiert man diese, die `dir()` Funktion zur Anzeige von Informationen zu Modulen, Einführung in die Struktur von Paketen (für größere Programmierprojekte)
- 8. [Ein- und Ausgabe](inputoutput.md): Ein- und Ausgabe mit print besser und flexibler formatieren, Lesen und Schreiben von Dateien, Daten strukturiert als JSON speichern
+ 8. [Eingabe und Ausgabe](inputoutput.md): Ein- und Ausgabe mit print besser und flexibler formatieren, Lesen und Schreiben von Dateien, Daten strukturiert als JSON speichern
  9. [Fehler und Ausnahmen (Exceptions)](errors.md): wie Python Fehler und Ausnahmen im Programmcode meldet, Umgang und Abfangen von Ausnahmen, eigene Ausnahmen definieren
  10. [Klassen](classes.md): wie man Klassen in Python erstellt und nutzt
  11. [Eine (kurze) Tour durch die Standardbibliothek](stdlib.md): kurze Vorstellung einiger gängiger und häufiger genutzter Module aus der Python Standardbibliothek

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ Es wird empfohlen das Tutorial chronologisch durchzuarbeiten. Die Reihenfolge de
  9. [Fehler und Ausnahmen (Exceptions)](errors.md): wie Python Fehler und Ausnahmen im Programmcode meldet, Umgang und Abfangen von Ausnahmen, eigene Ausnahmen definieren
  10. [Klassen](classes.md): wie man Klassen in Python erstellt und nutzt
  11. [Eine (kurze) Tour durch die Standardbibliothek](stdlib.md): kurze Vorstellung einiger gängiger und häufiger genutzter Module aus der Python Standardbibliothek
- 12. [Virtuelle Umgebungen und Paketverwaltung mit pip](venv.md): wie man virtellen Umgebungen (Virtual Environments) erstellt und nutzt sowie Python Pakete mit Hilfe von pip installiert
+ 12. [Virtuelle Umgebungen und Paketverwaltung mit pip](venv.md): wie man virtelle Umgebungen (Virtual Environments) erstellt und nutzt sowie Python Pakete mit Hilfe von pip installiert
  13. [Was kommt als Nächstes?](whatnow.md): hilfreiche Links und weiterführende Webseiten
  14. [Tipps und Anmerkungen](remarks.md): ein paar Tipps und Anmerkungen zu den ersten Projekten, GUI-Programmierung, nebenläufiger Programmierung und alternativen Python-Implementierung
  15. [Externe Module](externallibs.md): ein kurzer Überblick über einige viel genutzte und populäre externe Python-Module

--- a/docs/inputoutput.md
+++ b/docs/inputoutput.md
@@ -62,7 +62,7 @@ The value of x is 32.5, and y is 40000...
 
 Das [string-Modul](https://docs.python.org/3/library/string.html#module-string) enthält eine [string.Template Klasse](https://docs.python.org/3/library/string.html#string.Template), die eine weitere Möglichkeit bietet, Werte in Strings zu ersetzen, indem sie Platzhalter wie `$x` verwendet und diese durch Werte aus einem Wörterbuch ersetzt, dafür aber viel weniger Kontrolle über die Formatierung bietet.
 
-### formatierte String-Literale - f-Strings
+### Formatierte String-Literale - f-Strings
 
 Formatierte String-Literale, kurz f-Strings genannt, erlauben es, den Wert von Python-Ausdrücken in eine Zeichenkette einzuschließen, indem man der Zeichenkette ein `f` oder `F` voranstellt und Ausdrücke als `{Ausdruck}` schreibt.
 
@@ -108,7 +108,7 @@ Debugging bugs='roaches' count=13 area='living room'
 
 Weitere Informationen über den `=` Spezifizierer sind [in der Python-Dokumentation](https://docs.python.org/3/whatsnew/3.8.html#bpo-36817-whatsnew) zu finden. Eine Referenz zu diesen Formatspezifikationen finden man im Referenzhandbuch unter [Format Specification Mini-Language](https://docs.python.org/3/library/string.html#formatspec).
 
-### die String format() Method
+### Die str.format-Methode
 
 Die grundsätzliche Nutzung der `str.format` Methode sieht wie folgt aus:
 
@@ -179,7 +179,7 @@ Dies ist besonders nützlich in Kombination mit der eingebauten Funktion [vars](
 
 Eine vollständige Übersicht über die `string.format` Methode ist in der Python-Dokumentation unter [Format String Syntax](https://docs.python.org/3/library/string.html#formatstrings) zu finden.
 
-### manuellele String Formattierung
+### Manuellele String-Formatierung
 
 Das folgende Beispiel ist identisch mit dem vorherigen, nutzt aber eine vollständig manuelle Formatierung:
 
@@ -216,7 +216,7 @@ Es gibt eine weitere Methode, `str.zfill`, die eine numerische Zeichenkette auf 
 '3.14159265359'
 ```
 
-### die alte String-Formatierung
+### Die alte String-Formatierung
 
 Der %-Operator (modulo) kann auch für die Formatierung von Zeichenketten verwendet werden. In `format % values` (wobei `format` ein String ist) werden Instanzen von `%` in `format` durch null oder mehr Elemente von `values` ersetzt. Diese Operation ist allgemein als String-Interpolation bekannt. Zum Beispiel:
 
@@ -378,7 +378,7 @@ JSON-Dateien sind standardmäßig Textdateien die mit UTF-8 kodiert sein müssen
 
 Diese einfache Serialisierungstechnik kann mit Listen und Wörterbüchern umgehen, aber die Serialisierung beliebiger Klasseninstanzen in JSON erfordert ein wenig zusätzlichen Aufwand. Die Referenz für das Modul `json` enthält eine Erklärung dazu.
 
-### weitere Methoden
+### Weitere Methoden
 
 Im Gegensatz zu JSON ist [pickle](https://docs.python.org/3/library/pickle.html) ein Protokoll, das die Serialisierung beliebig komplexer Python-Objekte ermöglicht. Als solches ist es spezifisch für Python und kann nicht für die Kommunikation mit Anwendungen verwendet werden, die in anderen Sprachen geschrieben sind. Außerdem ist es standardmäßig unsicher. Die Deserialisierung von Pickle-Daten, die aus einer nicht vertrauenswürdigen Quelle stammen, kann beliebiger Code ausgeführt werden, wenn die Daten von einem geschickten Angreifer manipuliert wurden.
 
@@ -386,5 +386,5 @@ CSV-Dateien erlauben es, Daten strukturiert abzulegen mit einer Struktur ähnlic
 
 ***
 
- * nächstes Kapitel: [Fehler und Ausnahmen](errors.md)
- * vorheriges Kapitel: [Module](modules.md)
+ * Nächstes Kapitel: [Fehler und Ausnahmen](errors.md)
+ * Vorheriges Kapitel: [Module](modules.md)

--- a/docs/inputoutput.md
+++ b/docs/inputoutput.md
@@ -386,5 +386,6 @@ CSV-Dateien erlauben es, Daten strukturiert abzulegen mit einer Struktur ähnlic
 
 ***
 
- * Nächstes Kapitel: [Fehler und Ausnahmen](errors.md)
+ * Nächstes Kapitel: [Fehler und Ausnahmen (Exceptions)](errors.md)
  * Vorheriges Kapitel: [Module](modules.md)
+ * Zurück zur [Startseite](index.md)

--- a/docs/interpreter.md
+++ b/docs/interpreter.md
@@ -1,4 +1,4 @@
-# der Python-Interpreter
+# Der Python-Interpreter
 
 ## Installation
 Je nach verwendetem Betriebssystem ist der Python-Interpreter bereits vorinstalliert und kann direkt verwendet werden. Ansonsten lässt dieser sich einfach für eine Vielzahl von Plattformen nachinstallieren.
@@ -94,7 +94,7 @@ Fortsetzungszeilen werden benötigt, wenn ein mehrzeiliges Konstrukt eingegeben 
 Be careful not to fall off!
 ```
 
-## der Interpreter und seine Umgebung
+## Der Interpreter und seine Umgebung
 
 ### Quellcode Encoding
 
@@ -125,5 +125,5 @@ Sofern es keinen trifftigen Grund gibt, eine andere Codierung als UTF-8 zu nutze
 
 ***
 
- * nächste Seite: [eine ungezwungene Einführung in Python](introduction.md)
- * vorherige Seite: [ein kleiner Appetitanreger auf Python](appetite.md)
+ * Nächste Seite: [Eine ungezwungene Einführung in Python](introduction.md)
+ * Vorherige Seite: [Ein kleiner Appetitanreger auf Python](appetite.md)

--- a/docs/interpreter.md
+++ b/docs/interpreter.md
@@ -1,4 +1,4 @@
-# Der Python-Interpreter
+# Den Python-Interpreter nutzen
 
 ## Installation
 Je nach verwendetem Betriebssystem ist der Python-Interpreter bereits vorinstalliert und kann direkt verwendet werden. Ansonsten lässt dieser sich einfach für eine Vielzahl von Plattformen nachinstallieren.
@@ -125,5 +125,6 @@ Sofern es keinen trifftigen Grund gibt, eine andere Codierung als UTF-8 zu nutze
 
 ***
 
- * Nächste Seite: [Eine ungezwungene Einführung in Python](introduction.md)
- * Vorherige Seite: [Ein kleiner Appetitanreger auf Python](appetite.md)
+ * Nächstes Kapitel: [Eine lockere Einführung in Python](introduction.md)
+ * Vorheriges Kapitel: [Ein kleiner Appetitanreger auf Python](appetite.md)
+ * Zurück zur [Startseite](index.md)

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -510,3 +510,4 @@ Das Schlüsselwortargument *end* kann verwendet werden, um den Zeilenumbruch nac
 
  * Nächstes Kapitel: [Weitere Werkzeuge zur Steuerung des Programmflusses](controlflow.md)
  * Vorheriges Kapitel: [Den Python-Interpreter nutzen](interpreter.md)
+ * Zurück zur [Startseite](index.md)

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -508,5 +508,5 @@ Das Schlüsselwortargument *end* kann verwendet werden, um den Zeilenumbruch nac
 
 ***
 
- * nächstes Kapitel: [weitere Werkzeuge zur Steuerung des Programmflusses](controlflow.md)
- * vorheriges Kapitel: [den Python-Interpreter nutzen](interpreter.md)
+ * Nächstes Kapitel: [Weitere Werkzeuge zur Steuerung des Programmflusses](controlflow.md)
+ * Vorheriges Kapitel: [Den Python-Interpreter nutzen](interpreter.md)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -89,7 +89,7 @@ Hello World
 <class 'demo.EmptyClass'>
 ```
 
-## mehr zu Modulen
+## Mehr zu Modulen
 
 Ein Modul kann sowohl ausführbare Anweisungen als auch Funktionsdefinitionen enthalten. Diese Anweisungen dienen der Initialisierung des Moduls. Sie werden nur beim *ersten* Auftreten des Modulnamens in einer Import-Anweisung ausgeführt. Sie werden immer ausgeführt, auch wenn die Datei als Skript ausgeführt wird (dazu später in diesem Kapitel mehr).
 
@@ -226,7 +226,7 @@ Weiterführende Informationen sind in der Python-Dokumentation unter [The initia
 
 Nach der Initialisierung können Python-Programme `sys.path` ändern. Das Verzeichnis, das das auszuführende Skript enthält, wird an den Anfang des Suchpfades gesetzt, noch vor dem Pfad der Standardbibliothek. Das bedeutet, dass Skripte in diesem Verzeichnis anstelle von gleichnamigen Modulen im Bibliotheksverzeichnis geladen würden. Das führt in der Regel zu verwirrenden Fehlermeldungen, gerade bei Einsteigern. Von daher sollte man seinen Skripten immer eigenständige Namen geben, die nicht identisch mit den Namen von Standardmodulen bzw. zu importierenden Modulen sind.
 
-### kompilierte Python Dateien
+### Kompilierte Pythondateien
 
 Um das Laden von Modulen zu beschleunigen, speichert Python ein zu Python Bytecode kompilierte Version jedes Moduls im `__pycache__` Verzeichnis unter dem Namen `module.{version}.pyc`, wobei die Version das Format der kompilierten Datei kodiert. Sie enthält im Allgemeinen die Python-Versionsnummer. Zum Beispiel würde in CPython 3.9 die kompilierte Version von spam.py als `__pycache__/spam.cpython-39.pyc` zwischengespeichert werden. Diese Namenskonvention ermöglicht die Koexistenz von kompilierten Modulen aus verschiedenen Releases und verschiedenen Python-Versionen.
 
@@ -241,7 +241,7 @@ Einige Expertentipps:
 * Das Modul [compileall](https://docs.python.org/3/library/compileall.html#module-compileall) kann .pyc Dateien für alle Module in einem Verzeichnis erstellen.
 * Es gibt mehr Details über diesen Prozess, einschließlich Entscheidungsbaums, in der [PEP3147](https://peps.python.org/pep-3147/).
 
-## Standard Module
+## Standardmodule
 
 Python wird mit einer relativ umfangreichen Bibliothek von Standardmodulen ausgeliefert, die in der [Python Library Reference](https://docs.python.org/3/library/index.html) beschrieben sind. Einige Module sind in dem Interpreter eingebaut. Diese ermöglichen den Zugriff auf Operationen, die nicht Teil des Kerns der Sprache sind, aber dennoch eingebaut sind, entweder aus Gründen der Effizienz oder um den Zugriff auf Betriebssystemprimitive wie Systemaufrufe zu ermöglichen.
 
@@ -266,7 +266,7 @@ Die Variable `sys.path` ist eine Liste von Strings, die den Suchpfad des Interpr
 >>> sys.path.append('/ufs/guido/lib/python')
 ```
 
-## die dir() Funktion
+## Die dir-Funktion
 
 Die eingebaute Funktion [dir](https://docs.python.org/3/library/functions.html#dir) wird verwendet, um herauszufinden, welche Namen ein Modul definiert. Sie gibt eine sortierte Liste von Namen innerhalb des Moduls zurück:
 
@@ -484,5 +484,5 @@ Obwohl diese Funktion nicht oft benötigt wird, kann sie verwendet werden, um di
 
 ***
 
-* nächstes Kapitel: [Eingabe und Ausgabe](inputoutput.md)
-* vorheriges Kapitel: [Datenstrukturen und Datentypen](datastructures.md)
+* Nächstes Kapitel: [Eingabe und Ausgabe](inputoutput.md)
+* Vorheriges Kapitel: [Datenstrukturen und Datentypen](datastructures.md)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -484,5 +484,7 @@ Obwohl diese Funktion nicht oft benötigt wird, kann sie verwendet werden, um di
 
 ***
 
-* Nächstes Kapitel: [Eingabe und Ausgabe](inputoutput.md)
-* Vorheriges Kapitel: [Datenstrukturen und Datentypen](datastructures.md)
+ * Nächstes Kapitel: [Eingabe und Ausgabe](inputoutput.md)
+ * Vorheriges Kapitel: [Datenstrukturen und Datentypen](datastructures.md)
+ * Zurück zur [Startseite](index.md)
+ 

--- a/docs/remarks.md
+++ b/docs/remarks.md
@@ -76,5 +76,5 @@ Und es gibt noch diverse anderen Implementierung. Diese Unterscheiden sich in de
 
 ***
 
- * nächstes Kapitel: [externe Python Module](externallibs.md)
- * zurück zur [Startseite](index.md)
+ * Nächstes Kapitel: [Externe Python Module](externallibs.md)
+ * Zurück zur [Startseite](index.md)

--- a/docs/remarks.md
+++ b/docs/remarks.md
@@ -77,4 +77,5 @@ Und es gibt noch diverse anderen Implementierung. Diese Unterscheiden sich in de
 ***
 
  * Nächstes Kapitel: [Externe Python Module](externallibs.md)
+ * Vorheriges Kapitel: [Was kommt als Nächstes?](whatnow.md)
  * Zurück zur [Startseite](index.md)

--- a/docs/start.md
+++ b/docs/start.md
@@ -24,4 +24,5 @@ Dieses Tutorial erhebt nicht den Anspruch, umfassend oder vollumfänglich zu sei
 
 ***
 
-Nächste Seite: [Ein kleiner Appetitanreger](appetite.md) für Python
+ * Nächstes Kapitel: [Ein kleiner Appetitanreger auf Python](appetite.md)
+ * Zurück zur [Startseite](index.md)

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -369,5 +369,6 @@ Python hat standardmäßig noch drei weitere Module für nebenläufige Programmi
 
 ***
 
- * Nächstes Kapitel: [Venv - virtuelle Umgebungen für Python](venv.md)
+ * Nächstes Kapitel: [Virtuelle Umgebungen und Paketverwaltung mit pip](venv.md)
  * Vorheriges Kapitel: [Klassen](classes.md)
+ * Zurück zur [Startseite](index.md)

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -1,4 +1,4 @@
-# eine (kurze) Tour durch die Standardbibliothek
+# Eine (kurze) Tour durch die Standardbibliothek
 
 Wie an anderer Stelle bereits erwähnt, bringt die Python Standardinstallation eine sehr große Anzahl an Modulen für alle möglichen Aufgaben mit. Eine Übersicht gruppiert nach Themengebieten ist auf der Dokumentationsseite [Library Index](https://docs.python.org/3/library/index.html) zu finden.
 
@@ -7,7 +7,7 @@ Im Folgenden werden einige Module aus der Standardbibliothek (sehr) kurz vorgest
 Man muss (und realistischer Weise kann) sicherlich nicht alle Module aus der Standardbibliothek in- und auswendig kennen. Und das ist auch nicht wirklich notwendig. Aber es ist durchaus hilfreich, wenn man sich mehr mit Python beschäftigt und mehr damit programmiert, eine Idee zu haben, für welche Aufgaben es bereits ein fertiges Modul in der Standardbibliothek gibt. Das reduziert den eigenen Programmieraufwand und man ist schneller mit der Erstellung seines Programms fertig.
 
 ## Kommandozeilenargumente
-### sys.argv
+### Sys.argv
 
 Skripte müssen häufig Befehlszeilenargumente verarbeiten. Diese Argumente werden im argv-Attribut des [sys](https://docs.python.org/3/library/sys.html#module-sys) Moduls als Liste gespeichert. Nimmt man zum Beispiel die folgende Datei "demo.py":
 
@@ -32,7 +32,7 @@ Die Liste `sys.argv` enthält an erster Position, also am Index Null, immer den 
 
 Die Verwendung von `sys.argv` ist für das schnelle Testen oder einfache Argumente gut genug. Alle Argumente werden als String in die Liste aufgenommen. Auch wenn es wie im Falle der 2 eigentlich ein Integerwert ist.
 
-### argparse
+### Argparse
 
 Das [argparse](https://docs.python.org/3/library/argparse.html#module-argparse) Modul bietet einen ausgefeilteren Mechanismus zur Verarbeitung von Befehlszeilenargumenten. Das folgende Skript extrahiert einen oder mehrere Dateinamen und eine optionale Anzahl von Zeilen, die angezeigt werden sollen:
 
@@ -53,7 +53,7 @@ Wenn das Skript auf der Kommandozeile mit `python3 top.py --lines=5 alpha.txt be
 
 Das argparse-Modul ist immer die bessere Wahl als `sys.argv`, wenn man ein paar mehr und nicht-trivial Argumente übergeben will. Außerdem bietet argparse noch viel mehr Möglichkeiten wie die Ausgabe von Hilfstexten, Beschränkungen von Argumenten auf bestimmte Werte, sich gegenseitig ausschließende Argumente und vieles mehr.
 
-## String Pattern Matching - reguläre Ausdrücke
+## Reguläre Ausdrücke - String Pattern Matching
 
 Das Modul [re](https://docs.python.org/3/library/re.html#module-re) bietet Werkzeuge für [reguläre Ausdrücke](https://de.wikipedia.org/wiki/Regul%C3%A4rer_Ausdruck) zur erweiterten Verarbeitung von Zeichenketten. Für komplexe Übereinstimmungen und Manipulationen bieten reguläre Ausdrücke prägnante und optimierte Lösungen:
 
@@ -68,7 +68,7 @@ Das Modul [re](https://docs.python.org/3/library/re.html#module-re) bietet Werkz
 Mit dem re-Modul lässt sich Text nach (Teil-) Ausdrücken auch mit (sehr) komplexen Suchmustern durchsuchen.
 
 ## Mathematik
-### math
+### Math
 
 Das Modul [math](https://docs.python.org/3/library/math.html) ermöglicht den Zugriff auf die zugrunde liegenden C-Bibliotheksfunktionen für Mathematik:
 
@@ -80,7 +80,7 @@ Das Modul [math](https://docs.python.org/3/library/math.html) ermöglicht den Zu
 10.0
 ```
 
-## random
+## Random
 Das Modul [random](https://docs.python.org/3/library/random.html) stellt Werkzeuge zur Verfügung, um Zufallsauswahlen zu generieren:
 
 ```pycon
@@ -95,7 +95,7 @@ Das Modul [random](https://docs.python.org/3/library/random.html) stellt Werkzeu
 4
 ```
 
-### statistics
+### Statistics
 
 Das Modul [statistics](https://docs.python.org/3/library/statistics.html) berechnet die grundlegenden statistischen Eigenschaften (Mittelwert, Median, Varianz, etc.) von numerischen Daten:
 
@@ -171,7 +171,7 @@ Hinweis: Das Modul heißt "datetime" und enthält ein Submodul mit dem Namen "da
 >>> now = datetime.now()
 ```
 
-## pathlib - Umgang mit Pfaden und Verzeichnissen
+## Pathlib - Umgang mit Pfaden und Verzeichnissen
 Das Modul [pathlib](https://docs.python.org/3/library/pathlib.html) bietet eine Reihe von Klassen und Methoden zum Umgang mit Dateipfaden. Eine zentralle Klasse ist `Path`, welche einen Dateipfad darstellt.
 
 Das Modul bietet unter anderem das Zusammensetzen von neuen Pfaden aus mehreren Path-Objekte, die Extraktion von Pfad, Dateiname und Dateiendung aus einem Path-Objekt sowie das Iterieren über den Inhalt eines Path-Ojekts, sofern es sich dabei um einen Verzeichnis handelt.
@@ -229,7 +229,7 @@ class TestStatisticalFunctions(unittest.TestCase):
 unittest.main()  # Calling from the command line invokes all tests
 ```
 
-## locale - lokale Einstellungen für Zahlen und Währung
+## Locale - lokale Einstellungen für Zahlen und Währung
 
 Das Modul [locale](https://docs.python.org/3/library/locale.html#module-locale) greift auf eine Datenbank mit kulturspezifischen Datenformaten zu. Das Attribut `grouping` der locale-Formatfunktion bietet eine direkte Möglichkeit, Zahlen mit Gruppentrennzeichen zu formatieren:
 
@@ -351,7 +351,7 @@ Diese Werkzeuge sind zwar sehr leistungsfähig, aber kleine Designfehler können
 
 *Hinweis*: Threads, über das threading Modul in einem Python-Skript gestartet werden, laufen im Interpreter von CPython (welches hier, wie ganz am Anfang des Tutorials gesagt, behandelt wird) nicht parallel, es kann nur ein Thread gleichzeitig laufen. Dies ist durch Interna des Python-Interpreter an sich bedingt, nämlich den [GIL](https://wiki.python.org/moin/GlobalInterpreterLock) (ausgeschrieben: great interpreter lock). Wer mehr zu dem Thema wissen möchte, kann z.B. im Internet nach "python gil" suchen.
 
-### weitere Module für nebenläufige Programmierung
+### Weitere Module für nebenläufige Programmierung
 
 Python hat standardmäßig noch drei weitere Module für nebenläufige Programmierung an Bord:
 
@@ -359,7 +359,8 @@ Python hat standardmäßig noch drei weitere Module für nebenläufige Programmi
  * [concurrent.futures](https://docs.python.org/3/library/concurrent.futures.html): Das Modul `concurrent.futures` bietet eine High-Level-Schnittstelle für die asynchrone Ausführung von Aufgaben. Die Schnittstell ist für Threads und Multiprocessing identisch. Zentrales Element des Moduls die die `Executer` Klasse, die sich um die Aufgabenverteilung kümmert.
  * [asyncio](https://docs.python.org/3/library/asyncio.html): Nebenläufigkeit mit `async`/`await` Syntax. Besonders geeignet für asyncio für I/O-lastigem und hochstrukturierten Netzwerkcode.
 
-## weitere Module
+## Weitere Module
+
  * [iterttools](https://docs.python.org/3/library/itertools.html): Das Modul `itertools` bietet eine größere Sammlung von Funktionen, die verschiedene Iterator zum Iterieren über Sequenzen bereitstellen
  * [SQLite Datenbank](https://docs.python.org/3/library/sqlite3.html): Das Modul `sqlite3` ist ein Wrapper für die SQLite-Datenbankbibliothek und stellt eine persistente Datenbank zur Verfügung, die aus Python heraus genutzt werden kann.
  * [email](https://docs.python.org/3/library/email.html#module-email): Das E-Mail-Paket ist eine Bibliothek zur Verwaltung von E-Mail-Nachrichten, einschließlich MIME- und anderer RFC 2822-basierter Nachrichtendokumente. Im Gegensatz zu smtplib und poplib, die tatsächlich Nachrichten senden und empfangen, verfügt das E-Mail-Paket über ein komplettes Toolset zum Erstellen oder Dekodieren komplexer Nachrichtenstrukturen (einschließlich Anhängen) und zur Implementierung von Internet-Kodierungs- und Header-Protokollen.
@@ -368,5 +369,5 @@ Python hat standardmäßig noch drei weitere Module für nebenläufige Programmi
 
 ***
 
- * nächstes Kapitel: [venv - virtuelle Umgebungen für Python](venv.md)
- * vorheriges Kapitel: [Klassen](classes.md)
+ * Nächstes Kapitel: [Venv - virtuelle Umgebungen für Python](venv.md)
+ * Vorheriges Kapitel: [Klassen](classes.md)

--- a/docs/venv.md
+++ b/docs/venv.md
@@ -1,4 +1,4 @@
-# virtuelle Umgebungen und Paketverwaltung mit pip
+# Virtuelle Umgebungen und Paketverwaltung mit pip
 
 ## Einführung
 
@@ -14,7 +14,7 @@ Ein weiterer, damit einhergehender Vorteil ist, dass innerhalb einer virtuellen 
 
 Von daher gilt es im Allgemeinen als "best practice", in einer virtuellen Python-Umgebung zu arbeiten, sobald man Module aus externen Quellen nachinstallieren möchte oder muss. Außerdem kann es je nach verwendetem Betriebssystem und genutzter pip-Version (Informationen zu pip siehe Abschnitt *"Python Pakete mit pip verwalten"* weiter unten) vorkommen, dass pip die Nutzung einer virtuellen Umgebung forciert.
 
-## ein Virtual Environment anlegen
+## Ein Virtual Environment anlegen
 
 Das Modul, mit dem virtuelle Umgebungen erstellt und verwaltet werden, heißt [venv](https://docs.python.org/3/library/venv.html). `venv` ist normalerweise in der Python Standardinstallation enthalten. Bei manchen Linuxdistributionen kann es notwendig sein, das Paket **python3-venv** über die Paketverwaltung des Systems nachzuinstallieren.
 
@@ -175,5 +175,5 @@ Wenn man selber ein Python Modul im Python Packge Index veröffentlichen möchte
 
 ***
 
- * nächstes Kapitel: [Was kommt als nächstes?](whatnow.md)
- * vorheriges Kapitel: [eine (kurze) Tour durch die Standardbibliothek](stdlib.md)
+ * Nächstes Kapitel: [Was kommt als Nächstes?](whatnow.md)
+ * Vorheriges Kapitel: [Eine (kurze) Tour durch die Standardbibliothek](stdlib.md)

--- a/docs/venv.md
+++ b/docs/venv.md
@@ -177,3 +177,4 @@ Wenn man selber ein Python Modul im Python Packge Index veröffentlichen möchte
 
  * Nächstes Kapitel: [Was kommt als Nächstes?](whatnow.md)
  * Vorheriges Kapitel: [Eine (kurze) Tour durch die Standardbibliothek](stdlib.md)
+ * Zurück zur [Startseite](index.md)

--- a/docs/whatnow.md
+++ b/docs/whatnow.md
@@ -1,4 +1,4 @@
-# Was kommt als nächstes?
+# Was kommt als Nächstes?
 
 Die Lektüre dieses Tutorials bis hierher hat hoffentlich das Interesse an der Verwendung von Python gestärkt - und die ersten Python-Programm und Projekte sind bereits in Planung.
 
@@ -9,7 +9,7 @@ Auf der Webseite der Python Software Foundation [www.python.org](https://www.pyt
 
 Außerdem gibt es noch das [Python Wiki](https://wiki.python.org/moin/), wo man auch viele Artikel rund um Python findet.
 
-## weitere Webseiten
+## Weitere Webseiten
 Es gibt auch sehr viele weitere Webseite, Blogeinträge, Tutorials, kostenfreien und kostenpflichtigen Kursen im Internet rund um das Thema Python. Eine kleine Auswahl an empfehlenswerten Seiten davon ist:
 
  * [das deutsche Python-Forum](https://www.python-forum.de): privat, seit 2002 betriebenes Supportforum für die deutsche Python-Community. Primäre Anlaufstelle bei Fragen rund um Python Programmierung, Codereviews etc.
@@ -20,7 +20,7 @@ Es gibt auch sehr viele weitere Webseite, Blogeinträge, Tutorials, kostenfreien
  * [Real Python](https://realpython.com/): Teils kostenlose, teils kostenpflichte Sammlung von Python-Tutorials zu allen möglichen Themenbereichen. Viele der textbasierten Tutorials sind kostenlos lesbar, Videotutorials sind kostenpflichtig. In der Regel sind die Tutorials gut ausgearbeitet und verständlich geschrieben.
  * [Pycoder's Weeksly](https://pycoders.com/latest): Wöchentlicher, kostenloser Newsletter rund im Python. Enthält viele Links zu Artikel und Blogbeiträgen zu News und allgemeinen Python-Themen
 
-### gute vs. schlechte Webseiten
+### Gute vs. schlechte Webseiten
 Wie oben bereits erwähnt gibt es Unmengen an Webseiten zum Thema Python. Dabei reicht das Qualitätsspektrum von "einwandfrei" über "war mal gut, ist aber heute veraltet" bis hin zu "quasi unbrauchbar".
 
 Das Problem dabei, wenn man neu in einem Thema (wie Python-Programmierung) ist tut man sich naturgemäß schwer beim Lesen einer Webseite zum Thema Python Programmierung zu beurteilen, ob das gesagt gut, brauchbar oder unbrauchbar ist. "unbrauchbar" ist hier gemeint im Sinne von "würde so laufen, programmiert man aber besser nicht so - weil z.B. unpythonisch, fragil oder viel zu umständlich etc.
@@ -38,5 +38,5 @@ Das heißt auch, dass man eher früher als später auch englischsprachige Dokume
 
 ***
 
- * nächste Seite: [Tipps und Anmerkungen](remarks.md)
- * vorherige Seite: [virtuelle Umgebungen und Paketverwaltung mit pip](venv.md)
+ * Nächste Seite: [Tipps und Anmerkungen](remarks.md)
+ * Vorherige Seite: [Virtuelle Umgebungen und Paketverwaltung mit pip](venv.md)

--- a/docs/whatnow.md
+++ b/docs/whatnow.md
@@ -38,5 +38,6 @@ Das heißt auch, dass man eher früher als später auch englischsprachige Dokume
 
 ***
 
- * Nächste Seite: [Tipps und Anmerkungen](remarks.md)
- * Vorherige Seite: [Virtuelle Umgebungen und Paketverwaltung mit pip](venv.md)
+ * Nächstes Kapitel: [Tipps und Anmerkungen](remarks.md)
+ * Vorheriges Kapitel: [Virtuelle Umgebungen und Paketverwaltung mit pip](venv.md)
+ * Zurück zur [Startseite](index.md)


### PR DESCRIPTION
More phrases should be capitalised harmoniously:
- Titles of links to each chapter from the main page
- Headlines on top and throughout each chapter
- Titles of links in the footer of each chapter
- Descriptions of next/previous page in the footer
- Composed titles with hyphen like "Range-Funktion"

Yes, German uses more capitalized words than English.

A few issues with the links in the footer were also adjusted:
- All chapters seem to have a link to the next and previous chapter
- However, the few latest chapters did not follow this convention, yet
- I adjusted their links to also show the same links to next/previous chapter
- The footer in the last few chapters instead also linked to back the index page
- I added this link to navigate back to the index page to the footers of all chapters
- Some chapters named the links "chapter" and some "page". I settled for "chapter"
- The names in the links of the footer did not always match the chapters' titles. Updated.
- The last chapter 15 linked (not to a next chapter) but also back to chapter 11. Dropped said link.

Not done:
- There is maybe some markdown magic available in the doc generator engine so we can template the footer once and actually gather the other chapters' current titles from their very files, but that's a bigger task for another day.
- Both README.md and index.md seem to list the chapters and could be joint. Did not do that. Instead adjusted both files.